### PR TITLE
Kabit Savaiye Corrections

### DIFF
--- a/data/Kabit Savaiye/032.json
+++ b/data/Kabit Savaiye/032.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Be assured that the meeting of Guru and a disciple, makes a disciple realise Lord and virtually becomes like Him. His  heart then remains immersed in the celestial music. (32)",
+              "translation": "Be assured that the meeting of Guru and a disciple, makes a disciple realise Lord and virtually becomes like Him. His heart then remains immersed in the celestial music. (32)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/033.json
+++ b/data/Kabit Savaiye/033.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "By taking refuge of Sat guru's lotus feet, a devotee's mind )0 blooms like lotus flower. By the blessings of a True Guru, he treats and conducts himself alike with all and sundry. He carries no rancour for anyone.",
+              "translation": "By taking refuge of Sat guru's lotus feet, a devotee's mind too blooms like lotus flower. By the blessings of a True Guru, he treats and conducts himself alike with all and sundry. He carries no rancour for anyone.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/073.json
+++ b/data/Kabit Savaiye/073.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The company of a person for a second, who is deep into the meditation of Lord's name bless one with happiness, ecstasy and elixir of life. Like indestructible Lord, Satguru  is an epitome of eternal bliss. (73)",
+              "translation": "The company of a person for a second, who is deep into the meditation of Lord's name bless one with happiness, ecstasy and elixir of life. Like indestructible Lord, Satguru is an epitome of eternal bliss. (73)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/212.json
+++ b/data/Kabit Savaiye/212.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The dear beloved who has not one but many obedient consorts; the dispenser of kindness on the distressed, the  beloved has been clement on me.",
+              "translation": "The dear beloved who has not one but many obedient consorts; the dispenser of kindness on the distressed, the beloved has been clement on me.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/238.json
+++ b/data/Kabit Savaiye/238.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So would we face distress in the company of se1f-orien! self-willed people while association with Guru-conscious people enlightens the mind with Guru's wisdom which highly comforting. (238)",
+              "translation": "So would we face distress in the company of self-oriented self-willed people while association with Guru-conscious people enlightens the mind with Guru's wisdom which highly comforting. (238)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/270.json
+++ b/data/Kabit Savaiye/270.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Praise and panegyrics of the True Guru who is an image of the complete Lord is beyond mention and elucidation. The best way to express one's love and respect for Him is to salute Him again and again while addressing Him- \"0 Lord, Master! You are infinite,",
+              "translation": "Praise and panegyrics of the True Guru who is an image of the complete Lord is beyond mention and elucidation. The best way to express one's love and respect for Him is to salute Him again and again while addressing Him- \"O Lord, Master! You are infinite,",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/303.json
+++ b/data/Kabit Savaiye/303.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Lord (Bhagwan) tells sage Narad, 0 dear devotee! Congregation of Guru-conscious and true people is my abode if company is my glimpse.",
+              "translation": "Lord (Bhagwan) tells sage Narad, O dear devotee! Congregation of Guru-conscious and true people is my abode if company is my glimpse.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/314.json
+++ b/data/Kabit Savaiye/314.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "But I am blind, dumb, deaf, maimed of hand and feet a mass of suffering. 0 my True Lord! You are the wisest and completely informed of all my innate pains. 0 My Lord, please be merciful and remove all my pains. (314)",
+              "translation": "But I am blind, dumb, deaf, maimed of hand and feet a mass of suffering. O my True Lord! You are the wisest and completely informed of all my innate pains. O My Lord, please be merciful and remove all my pains. (314)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/373.json
+++ b/data/Kabit Savaiye/373.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similar is the significance of the lodging of true Guru's teachings in the hearts of obedient Sikhs of the Guru. This is reckoned only on reaching the divine court of the Lord. (The practitioners of Naam are honoured in His court).  (373)",
+              "translation": "Similar is the significance of the lodging of true Guru's teachings in the hearts of obedient Sikhs of the Guru. This is reckoned only on reaching the divine court of the Lord. (The practitioners of Naam are honoured in His court). (373)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/375.json
+++ b/data/Kabit Savaiye/375.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, many forms of philosophical tomes, the four caste system, the four abodes of life and religions are known as the branches of the household life. (They all are there because of the household life).  (375)",
+              "translation": "Similarly, many forms of philosophical tomes, the four caste system, the four abodes of life and religions are known as the branches of the household life. (They all are there because of the household life). (375)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/376.json
+++ b/data/Kabit Savaiye/376.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as the knowledge imparted by the True Guru is supreme of all knowledge, and concentration of mind on True Guru is superb, so is the family life ideal and superior of all the religions (ways of life).  (376)",
+              "translation": "Just as the knowledge imparted by the True Guru is supreme of all knowledge, and concentration of mind on True Guru is superb, so is the family life ideal and superior of all the religions (ways of life). (376)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/377.json
+++ b/data/Kabit Savaiye/377.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a disciple taking refuge of the True Guru and getting initiation from him is that the Sikh of the Guru adopts the teachings of the True Guru in his heart and lives his life accordingly.  (377)",
+              "translation": "Similarly, a disciple taking refuge of the True Guru and getting initiation from him is that the Sikh of the Guru adopts the teachings of the True Guru in his heart and lives his life accordingly. (377)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/378.json
+++ b/data/Kabit Savaiye/378.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So does the True Guru bless the Sikhs in His refuge with divine knowledge and high state of equipoise, thus obliterating their ill deeds performed in ignorance.  (378)",
+              "translation": "So does the True Guru bless the Sikhs in His refuge with divine knowledge and high state of equipoise, thus obliterating their ill deeds performed in ignorance. (378)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/379.json
+++ b/data/Kabit Savaiye/379.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is the great benefactor True Guru who like a philosopher stone is capable of turning the Sikhs into gold-like metal. He does not dwell on their erstwhile deeds and by blessing them with Naam Simran, make them virtuous like Himself.  (379)",
+              "translation": "So is the great benefactor True Guru who like a philosopher stone is capable of turning the Sikhs into gold-like metal. He does not dwell on their erstwhile deeds and by blessing them with Naam Simran, make them virtuous like Himself. (379)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/380.json
+++ b/data/Kabit Savaiye/380.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an obedient Sikh of the Guru who lodges the teachings of True Guru in his mind and engrosses his consciousness in the divine word is known the world over.  (380)",
+              "translation": "Similarly, an obedient Sikh of the Guru who lodges the teachings of True Guru in his mind and engrosses his consciousness in the divine word is known the world over. (380)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/382.json
+++ b/data/Kabit Savaiye/382.json
@@ -109,7 +109,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, by virtue of their good deeds, the obedient Sikhs of the Guru achieve high status in society while those who indulge in vices are easily recognised by their bad deeds.  (382)",
+              "translation": "Similarly, by virtue of their good deeds, the obedient Sikhs of the Guru achieve high status in society while those who indulge in vices are easily recognised by their bad deeds. (382)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/384.json
+++ b/data/Kabit Savaiye/384.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly the mammon (maya) becomes good for obedient Sikhs of the Guru who use it for good of others according to the teachings of the Guru. But the same mammon becomes troublesome to the worldly people and causes them distress and sufferings.  (384)",
+              "translation": "Similarly the mammon (maya) becomes good for obedient Sikhs of the Guru who use it for good of others according to the teachings of the Guru. But the same mammon becomes troublesome to the worldly people and causes them distress and sufferings. (384)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/385.json
+++ b/data/Kabit Savaiye/385.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, mammon is evil of character for the worldly people but for the obedient Sikhs of the True Guru, it is highly philanthropic since it does good to many in their hands.  (385)",
+              "translation": "Similarly, mammon is evil of character for the worldly people but for the obedient Sikhs of the True Guru, it is highly philanthropic since it does good to many in their hands. (385)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/386.json
+++ b/data/Kabit Savaiye/386.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, those of base wisdom and turned away from the True Guru have no love or attraction for the company of saintly persons. They are ever engrossed in creating troubles and doing ill deeds.  (386)",
+              "translation": "Similarly, those of base wisdom and turned away from the True Guru have no love or attraction for the company of saintly persons. They are ever engrossed in creating troubles and doing ill deeds. (386)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/387.json
+++ b/data/Kabit Savaiye/387.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "He destroys the vices and knows all the latent deeds of everyone. He is a companion who stands by in all thick and thin situations. Such a Lord is the treasure-house of elixir for those who relish His divine nectar.  (387)",
+              "translation": "He destroys the vices and knows all the latent deeds of everyone. He is a companion who stands by in all thick and thin situations. Such a Lord is the treasure-house of elixir for those who relish His divine nectar. (387)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/388.json
+++ b/data/Kabit Savaiye/388.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is developing loving relationship with evil-minded persons. Loving him or showing dissent towards him is equally bad. Thus one cannot escape from pain and sufferings of this world and the world hereafter.  (388)",
+              "translation": "So is developing loving relationship with evil-minded persons. Loving him or showing dissent towards him is equally bad. Thus one cannot escape from pain and sufferings of this world and the world hereafter. (388)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/389.json
+++ b/data/Kabit Savaiye/389.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, meeting with an evil and vice-ridden person, all comforts and good deeds shrink to such a size as if an ocean has been reduced to the size of a small cup.  (389)",
+              "translation": "Similarly, meeting with an evil and vice-ridden person, all comforts and good deeds shrink to such a size as if an ocean has been reduced to the size of a small cup. (389)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/390.json
+++ b/data/Kabit Savaiye/390.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is the nature of True Guru-oriented obedient Sikhs who are tender and malleable like water and wax. On the other hand, the temperament of mammon-loving person is rigid and hard like shellac and stone and thus is destructive.  (390)",
+              "translation": "So is the nature of True Guru-oriented obedient Sikhs who are tender and malleable like water and wax. On the other hand, the temperament of mammon-loving person is rigid and hard like shellac and stone and thus is destructive. (390)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/394.json
+++ b/data/Kabit Savaiye/394.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly an obedient disciple of the Guru feels pleased and blossoms at the sight of the True Guru. And by acquiring the treasure-house of divine knowledge and consecration of Naam Simran from his True Guru, he becomes a pious person.  (394)",
+              "translation": "Similarly an obedient disciple of the Guru feels pleased and blossoms at the sight of the True Guru. And by acquiring the treasure-house of divine knowledge and consecration of Naam Simran from his True Guru, he becomes a pious person. (394)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/395.json
+++ b/data/Kabit Savaiye/395.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "But within himself, he remains focused on the divine sight of the God-like True Guru. (According to Bhai Gurdas Ji, practicing on the Guru's words and meditating on Lord's name given by the True Guru is contemplation on the vision of True Guru).  (395)",
+              "translation": "But within himself, he remains focused on the divine sight of the God-like True Guru. (According to Bhai Gurdas Ji, practicing on the Guru's words and meditating on Lord's name given by the True Guru is contemplation on the vision of True Guru). (395)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/402.json
+++ b/data/Kabit Savaiye/402.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the Sikhs of the Guru are frightened, amazed, distressed and morose seeing the body/limbs of a spurious Guru marked with artificial marks of recognition. Even the Sikhs most close to the Guru feel restless.  (402)",
+              "translation": "Similarly, the Sikhs of the Guru are frightened, amazed, distressed and morose seeing the body/limbs of a spurious Guru marked with artificial marks of recognition. Even the Sikhs most close to the Guru feel restless. (402)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/403.json
+++ b/data/Kabit Savaiye/403.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "And even if more of such worldly tribulations and distresses may befall upon Guru-loving, obedient and meditating persons dear to the True Guru, they are least troubled by them and live life ever in bloom and happiness.  (403)",
+              "translation": "And even if more of such worldly tribulations and distresses may befall upon Guru-loving, obedient and meditating persons dear to the True Guru, they are least troubled by them and live life ever in bloom and happiness. (403)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/406.json
+++ b/data/Kabit Savaiye/406.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The True Guru is perfect in all respects. He is beyond our perception. No one can fathom his vast knowledge. He alone knows His own capabilities. All that can be said is-He is Infinite, Infinite, Infinite.   (406)",
+              "translation": "The True Guru is perfect in all respects. He is beyond our perception. No one can fathom his vast knowledge. He alone knows His own capabilities. All that can be said is-He is Infinite, Infinite, Infinite.  (406)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/407.json
+++ b/data/Kabit Savaiye/407.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So, considering someone high or low, good or bad because of the place of his birth or family lineage is just a misconception. This is an indescribable and wondrous play of the Lord that no one can know.   (407)",
+              "translation": "So, considering someone high or low, good or bad because of the place of his birth or family lineage is just a misconception. This is an indescribable and wondrous play of the Lord that no one can know.  (407)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/408.json
+++ b/data/Kabit Savaiye/408.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "He who holds the apron of the casteless and classless Lord, is never noticed for his caste and family lineage. One is able to destroy the cycles of incarnation by coming to the refuge of stable and immovable Lord.  (408)",
+              "translation": "He who holds the apron of the casteless and classless Lord, is never noticed for his caste and family lineage. One is able to destroy the cycles of incarnation by coming to the refuge of stable and immovable Lord. (408)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/409.json
+++ b/data/Kabit Savaiye/409.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Who ever is blessed with the collyrium of knowledge of the True Guru, recognises the mammon-free Lord God. But such a person who is able to achieve that state is rare in the world.  (409)",
+              "translation": "Who ever is blessed with the collyrium of knowledge of the True Guru, recognises the mammon-free Lord God. But such a person who is able to achieve that state is rare in the world. (409)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/410.json
+++ b/data/Kabit Savaiye/410.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So does a devoted disciple of the True Guru whose heart is kindled with the Love of the Lord, the whole world beseeches and whines at his door.  (410)",
+              "translation": "So does a devoted disciple of the True Guru whose heart is kindled with the Love of the Lord, the whole world beseeches and whines at his door. (410)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/411.json
+++ b/data/Kabit Savaiye/411.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the Guru-oriented Sikh whose heart is enlightened by the love of the Lord and His meditation, cannot remain hidden. His silence gives him away.  (411)",
+              "translation": "Similarly, the Guru-oriented Sikh whose heart is enlightened by the love of the Lord and His meditation, cannot remain hidden. His silence gives him away. (411)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/412.json
+++ b/data/Kabit Savaiye/412.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if a devoted Sikh renounces True Guru's service, His teachings and contemplation of His name, is engrossed in worldly quandary, he then cannot attain the status of an obedient disciple of the True Guru in the holy congregation of Guru.  (412)",
+              "translation": "Similarly, if a devoted Sikh renounces True Guru's service, His teachings and contemplation of His name, is engrossed in worldly quandary, he then cannot attain the status of an obedient disciple of the True Guru in the holy congregation of Guru. (412)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/413.json
+++ b/data/Kabit Savaiye/413.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Ants, cranes and deers keep following their leader, but supreme leader of all the species who leaves the well defined path of the True Guru, is surely a fool and a highly ignorant person.  (413)",
+              "translation": "Ants, cranes and deers keep following their leader, but supreme leader of all the species who leaves the well defined path of the True Guru, is surely a fool and a highly ignorant person. (413)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/415.json
+++ b/data/Kabit Savaiye/415.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, True Guru holds a congregation of his disciples in order to impart them with supreme form of knowledge (Naam). But he who remains bereft of Guru's teachings, is worthy of condemnation and is a blotch on the human birth.  (415)",
+              "translation": "Similarly, True Guru holds a congregation of his disciples in order to impart them with supreme form of knowledge (Naam). But he who remains bereft of Guru's teachings, is worthy of condemnation and is a blotch on the human birth. (415)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/417.json
+++ b/data/Kabit Savaiye/417.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the whole world may go to the refuge of the True Guru but he alone attains the status of living emancipated who 'is liked by Him. (That particular disciple who serves Guru with faith and devotion).  (417)",
+              "translation": "Similarly, the whole world may go to the refuge of the True Guru but he alone attains the status of living emancipated who 'is liked by Him. (That particular disciple who serves Guru with faith and devotion). (417)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/418.json
+++ b/data/Kabit Savaiye/418.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the True Guru who has merged with the Light divine of the Lord, like warp and weft of a cloth, alone can make a disciple living emancipated with His teachings.  (418)",
+              "translation": "Similarly, the True Guru who has merged with the Light divine of the Lord, like warp and weft of a cloth, alone can make a disciple living emancipated with His teachings. (418)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/419.json
+++ b/data/Kabit Savaiye/419.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a disciple who has turned away from the holy feet of the True Guru comes back to the Guru's refuge when he feels the pain of his actions. Although he is freed of his sins and becomes pious, yet the .blemish of his apostasy remains.  (419)",
+              "translation": "Similarly, a disciple who has turned away from the holy feet of the True Guru comes back to the Guru's refuge when he feels the pain of his actions. Although he is freed of his sins and becomes pious, yet the .blemish of his apostasy remains. (419)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/421.json
+++ b/data/Kabit Savaiye/421.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The forehead that acquires a small amount of dust of the lotus feet of the True Guru, the glory of his glimpse is beyond description.  (421)",
+              "translation": "The forehead that acquires a small amount of dust of the lotus feet of the True Guru, the glory of his glimpse is beyond description. (421)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/423.json
+++ b/data/Kabit Savaiye/423.json
@@ -63,7 +63,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as the rain-bird is never tired of crying for the nectar like Swati drop day  and night, similarly the tongue of a devoted and obedient disciple of Guru is never tired of repeatedly uttering the ambrosial Naam of the Lord.",
+              "translation": "Just as the rain-bird is never tired of crying for the nectar like Swati drop day and night, similarly the tongue of a devoted and obedient disciple of Guru is never tired of repeatedly uttering the ambrosial Naam of the Lord.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/424.json
+++ b/data/Kabit Savaiye/424.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is the love of a Guru-conscious saint, the seeker of ambrosial nectar for his dear True Guru. The longing of love for his Guru that has permeated in every limb of his body and is flowing rapidly never decreases.  (424)",
+              "translation": "So is the love of a Guru-conscious saint, the seeker of ambrosial nectar for his dear True Guru. The longing of love for his Guru that has permeated in every limb of his body and is flowing rapidly never decreases. (424)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/427.json
+++ b/data/Kabit Savaiye/427.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Their state is unique and astonishing. In this amazing condition, they are beyond the attractions of body relishments and remain in a blooming state of bliss.  (427)",
+              "translation": "Their state is unique and astonishing. In this amazing condition, they are beyond the attractions of body relishments and remain in a blooming state of bliss. (427)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/428.json
+++ b/data/Kabit Savaiye/428.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "One can become unattached and free from all worldly allurements only by taking the refuge of the True Guru and practicing His sermon of Naam Simran that helps one achieve spiritual high, comfort of equipoise and humility.  (428)",
+              "translation": "One can become unattached and free from all worldly allurements only by taking the refuge of the True Guru and practicing His sermon of Naam Simran that helps one achieve spiritual high, comfort of equipoise and humility. (428)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/429.json
+++ b/data/Kabit Savaiye/429.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Engrossed in the refuge of ocean of peace-The True Guru, and by His grace, he too becomes an invaluable and an unique pearl like the pearl of the oyster.  (429)",
+              "translation": "Engrossed in the refuge of ocean of peace-The True Guru, and by His grace, he too becomes an invaluable and an unique pearl like the pearl of the oyster. (429)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/430.json
+++ b/data/Kabit Savaiye/430.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The fortunate devout who is blessed with the consecration of Naam by the True Guru, how high a spiritual state can his mind get absorbed in? No one is capable of expressing and describing this condition.  (430)",
+              "translation": "The fortunate devout who is blessed with the consecration of Naam by the True Guru, how high a spiritual state can his mind get absorbed in? No one is capable of expressing and describing this condition. (430)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/431.json
+++ b/data/Kabit Savaiye/431.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "By virtue of the loving merits of the Naam blessed by the radiant True Guru, a Sikh of the Guru attains supreme spiritual state and rejects all other worldly contemplations and awarenesses that put one in wandering of doubts.  (431)",
+              "translation": "By virtue of the loving merits of the Naam blessed by the radiant True Guru, a Sikh of the Guru attains supreme spiritual state and rejects all other worldly contemplations and awarenesses that put one in wandering of doubts. (431)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/433.json
+++ b/data/Kabit Savaiye/433.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly a devoted slave disciple goes to the refuge of the holy feet of the True Guru; enjoying His sight and entranced in His love, he keeps smiling within while relishing the divine spectacle.  (433)",
+              "translation": "Similarly a devoted slave disciple goes to the refuge of the holy feet of the True Guru; enjoying His sight and entranced in His love, he keeps smiling within while relishing the divine spectacle. (433)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/435.json
+++ b/data/Kabit Savaiye/435.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "What can one do with his own efforts ? Nothing tangible can be achieved by one's own efforts. All this is His blessing. One whose hard work and devotion is accepted by the Lord, gets all peace and comforts from Him.  (435)",
+              "translation": "What can one do with his own efforts ? Nothing tangible can be achieved by one's own efforts. All this is His blessing. One whose hard work and devotion is accepted by the Lord, gets all peace and comforts from Him. (435)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/436.json
+++ b/data/Kabit Savaiye/436.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "His mysterious play is beyond explanation and is astonishing. No one can know on whom will He be kind when and where and who will receive His blessings.  (436)",
+              "translation": "His mysterious play is beyond explanation and is astonishing. No one can know on whom will He be kind when and where and who will receive His blessings. (436)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/441.json
+++ b/data/Kabit Savaiye/441.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if a devoted disciple of Guru leaves the refuge of his Guru and goes into the protection of other gods and goddesses, he cannot find his stay there worthwhile nor anyone would show any respect and regard towards him being a blemished sinner.  (",
+              "translation": "Similarly, if a devoted disciple of Guru leaves the refuge of his Guru and goes into the protection of other gods and goddesses, he cannot find his stay there worthwhile nor anyone would show any respect and regard towards him being a blemished sinner. (",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/442.json
+++ b/data/Kabit Savaiye/442.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a deceitful Sikh with demonstrative love is the follower of other gods and goddesses, whereas the love of a true and obedient Sikh for his True Guru is like fish and water. (He holds no love for anyone else other than the True Guru).  (442)",
+              "translation": "Similarly, a deceitful Sikh with demonstrative love is the follower of other gods and goddesses, whereas the love of a true and obedient Sikh for his True Guru is like fish and water. (He holds no love for anyone else other than the True Guru). (442)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/443.json
+++ b/data/Kabit Savaiye/443.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a devotee and follower of other gods and goddesses, cannot know the celestial bliss of service of true and perfect Guru. Just as camel-thorn (Alhagi maurorum) resents rain.  (443)",
+              "translation": "Similarly, a devotee and follower of other gods and goddesses, cannot know the celestial bliss of service of true and perfect Guru. Just as camel-thorn (Alhagi maurorum) resents rain. (443)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/444.json
+++ b/data/Kabit Savaiye/444.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the radiant and benevolent True Guru is the support of the destitute. He does not keep in mind the mistakes of those Sikhs who have separated themselves from the door of their Guru and are wandering on the door of gods and goddesses.  (444)",
+              "translation": "Similarly, the radiant and benevolent True Guru is the support of the destitute. He does not keep in mind the mistakes of those Sikhs who have separated themselves from the door of their Guru and are wandering on the door of gods and goddesses. (444)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/445.json
+++ b/data/Kabit Savaiye/445.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the servant of other gods cannot realise the ecstasy of serving the True Guru, because the chronic and bad habits of the followers of god cannot perish.  (445)",
+              "translation": "Similarly, the servant of other gods cannot realise the ecstasy of serving the True Guru, because the chronic and bad habits of the followers of god cannot perish. (445)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/446.json
+++ b/data/Kabit Savaiye/446.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is the fruit of the service of gods who live life in the three traits of maya. Their reward is also influenced by the three traits of mammon. Only the service of the True Guru maintains the flow of the Naam-Bani elixir for ever.  (446)",
+              "translation": "So is the fruit of the service of gods who live life in the three traits of maya. Their reward is also influenced by the three traits of mammon. Only the service of the True Guru maintains the flow of the Naam-Bani elixir for ever. (446)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/447.json
+++ b/data/Kabit Savaiye/447.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Despite belonging to a Guru like a faithful wife, if a person does not acknowledge the support of his Guru firmly and wanders at the door of one god or the other, he cannot reach the supreme state of Oneness with God having been caught in duality.  (447)",
+              "translation": "Despite belonging to a Guru like a faithful wife, if a person does not acknowledge the support of his Guru firmly and wanders at the door of one god or the other, he cannot reach the supreme state of Oneness with God having been caught in duality. (447)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/448.json
+++ b/data/Kabit Savaiye/448.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The father Guru protects and brings up the specially virtuous children. Such Sikhs are freed of all rites and rituals by the Guru during their life-time, and instills the ideology and thoughts of one Lord in their mind.  (448)",
+              "translation": "The father Guru protects and brings up the specially virtuous children. Such Sikhs are freed of all rites and rituals by the Guru during their life-time, and instills the ideology and thoughts of one Lord in their mind. (448)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/450.json
+++ b/data/Kabit Savaiye/450.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Such a woman of deceitful love should have perished in her mother's womb. Deceit filled love is full of such duality as the two demons Rahu and Ketu are who cause solar and lunar eclipse.  (450)",
+              "translation": "Such a woman of deceitful love should have perished in her mother's womb. Deceit filled love is full of such duality as the two demons Rahu and Ketu are who cause solar and lunar eclipse. (450)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/452.json
+++ b/data/Kabit Savaiye/452.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as a heron does not fit in the group of swans and is turned out from there, so does a devotee of some god or goddess not fit into the holy assembly of God-worshipping saints. Such fake devotees should be turned out from these assemblies.  (452)",
+              "translation": "Just as a heron does not fit in the group of swans and is turned out from there, so does a devotee of some god or goddess not fit into the holy assembly of God-worshipping saints. Such fake devotees should be turned out from these assemblies. (452)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/454.json
+++ b/data/Kabit Savaiye/454.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if a follower of other god comes to the refuge of the perfect True Guru, he will find that his store-house is filled with all types of trading commodities (of loving worship).  (454)",
+              "translation": "Similarly, if a follower of other god comes to the refuge of the perfect True Guru, he will find that his store-house is filled with all types of trading commodities (of loving worship). (454)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/455.json
+++ b/data/Kabit Savaiye/455.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Living in the world of maya (mammon), the disciples of the Guru who have remained unsoiled of it have learnt that in this dark eons, the meditation on the name of God-like True Guru is supreme.  (455)",
+              "translation": "Living in the world of maya (mammon), the disciples of the Guru who have remained unsoiled of it have learnt that in this dark eons, the meditation on the name of God-like True Guru is supreme. (455)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/457.json
+++ b/data/Kabit Savaiye/457.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A devoted Sikh of the Guru who in the company of saintly persons, and serving the Lord-like True Guru has engrossed his mind in the divine word, is in reality the real scholar of the Lord.  (457)",
+              "translation": "A devoted Sikh of the Guru who in the company of saintly persons, and serving the Lord-like True Guru has engrossed his mind in the divine word, is in reality the real scholar of the Lord. (457)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/460.json
+++ b/data/Kabit Savaiye/460.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, without the service of perfect Guru, if someone becomes a follower of any other god/goddess, it is like a fly who giving up the fragrance of sandalwood goes and sits on foul smelling filth.  (460)",
+              "translation": "Similarly, without the service of perfect Guru, if someone becomes a follower of any other god/goddess, it is like a fly who giving up the fragrance of sandalwood goes and sits on foul smelling filth. (460)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/462.json
+++ b/data/Kabit Savaiye/462.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "True Guru is the embodiment of the complete and perfect Lord, the light is one that exists both in Absolute and Transcendental form. The same Effulgent Lord is getting Himself worshipped in the form of True Guru.  (462)",
+              "translation": "True Guru is the embodiment of the complete and perfect Lord, the light is one that exists both in Absolute and Transcendental form. The same Effulgent Lord is getting Himself worshipped in the form of True Guru. (462)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/466.json
+++ b/data/Kabit Savaiye/466.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is a devoted disciple of the True Guru who does not worship any other god or goddess except the dearer than his life-True Guru. But, by remaining in a state of tranquility, he neither disrespects anyone nor shows the arrogance of his supremacy.  (466)",
+              "translation": "So is a devoted disciple of the True Guru who does not worship any other god or goddess except the dearer than his life-True Guru. But, by remaining in a state of tranquility, he neither disrespects anyone nor shows the arrogance of his supremacy. (466)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/467.json
+++ b/data/Kabit Savaiye/467.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if a devout Sikh of Guru worships other gods and goddesses to assuage his addiction, what to speak of his liberation, he even bears the punishment of the angels of death. His life is condemned by the world.  (467)",
+              "translation": "Similarly, if a devout Sikh of Guru worships other gods and goddesses to assuage his addiction, what to speak of his liberation, he even bears the punishment of the angels of death. His life is condemned by the world. (467)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/470.json
+++ b/data/Kabit Savaiye/470.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a worshipper of other gods cannot understand the significance of serving True Guru. He is like a deaf and dumb person 'whose mind is not at all receptive to the sermons of the True Guru and therefore cannot act upon them.  (470)",
+              "translation": "Similarly, a worshipper of other gods cannot understand the significance of serving True Guru. He is like a deaf and dumb person 'whose mind is not at all receptive to the sermons of the True Guru and therefore cannot act upon them. (470)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/471.json
+++ b/data/Kabit Savaiye/471.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, serving gods cannot emancipate one from repeated births and deaths. One can achieve the higher spiritual state by becoming an obedient disciple of the True Guru.  (471)",
+              "translation": "Similarly, serving gods cannot emancipate one from repeated births and deaths. One can achieve the higher spiritual state by becoming an obedient disciple of the True Guru. (471)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/472.json
+++ b/data/Kabit Savaiye/472.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, no god or goddess can have the amount of kindness that the clement True Guru showers on His Sikhs. One may wander in realms and regions from East to West in search of it.  (472)",
+              "translation": "Similarly, no god or goddess can have the amount of kindness that the clement True Guru showers on His Sikhs. One may wander in realms and regions from East to West in search of it. (472)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/473.json
+++ b/data/Kabit Savaiye/473.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the cycle of birth and death cannot end by worshipping or serving any god or goddess. Without taking the refuge of the perfect True Guru, no one can achieve salvation.  (473)",
+              "translation": "Similarly, the cycle of birth and death cannot end by worshipping or serving any god or goddess. Without taking the refuge of the perfect True Guru, no one can achieve salvation. (473)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/474.json
+++ b/data/Kabit Savaiye/474.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly it is foolishness to seek spiritual knowledge from other gods and goddesses leaving the True Guru who is perfect manifestation of the Lord. No one else can impart this wisdom or knowledge.  (474)",
+              "translation": "Similarly it is foolishness to seek spiritual knowledge from other gods and goddesses leaving the True Guru who is perfect manifestation of the Lord. No one else can impart this wisdom or knowledge. (474)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/476.json
+++ b/data/Kabit Savaiye/476.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Without acquiring the teachings and wisdom from True Guru, service of other gods and goddesses give distress only. Loving them puts one in sufferings both in this world and the world hereafter.  (476)",
+              "translation": "Without acquiring the teachings and wisdom from True Guru, service of other gods and goddesses give distress only. Loving them puts one in sufferings both in this world and the world hereafter. (476)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/477.json
+++ b/data/Kabit Savaiye/477.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if son of a Guru's Sikh starts worshipping gods and goddesses, his human birth would be a failure just as a son of two fathers would be in a respectable family.  (477)",
+              "translation": "Similarly, if son of a Guru's Sikh starts worshipping gods and goddesses, his human birth would be a failure just as a son of two fathers would be in a respectable family. (477)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/479.json
+++ b/data/Kabit Savaiye/479.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "But if someone leaves the service of the True Guru, and becomes a follower of some other god, then he wastes away his human life and he is laughed at by others being known as a bad son.  (479)",
+              "translation": "But if someone leaves the service of the True Guru, and becomes a follower of some other god, then he wastes away his human life and he is laughed at by others being known as a bad son. (479)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/481.json
+++ b/data/Kabit Savaiye/481.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "In the desire of the sacred name, the True Guru blesses His Sikhs with food, bedding, clothing, mansions and other worldly assets. He removes all their duality of serving and following other gods and goddesses.  (481)",
+              "translation": "In the desire of the sacred name, the True Guru blesses His Sikhs with food, bedding, clothing, mansions and other worldly assets. He removes all their duality of serving and following other gods and goddesses. (481)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/483.json
+++ b/data/Kabit Savaiye/483.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the disciples of the Guru are never blemished while leading a householder's life. Like loyal and faithful wife, they consider indulgence of worship of any other god over the True Guru as a condemnable act in the world.  (483)",
+              "translation": "Similarly, the disciples of the Guru are never blemished while leading a householder's life. Like loyal and faithful wife, they consider indulgence of worship of any other god over the True Guru as a condemnable act in the world. (483)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/484.json
+++ b/data/Kabit Savaiye/484.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "No one can tell the day of the creation of this cosmos. Then how can one know the birthday of such Lord who is Ajuni (beyond birth) ? Thus worship of gods who are born and who die is futile. Worship of eternal Lord is only purposeful.  (484)",
+              "translation": "No one can tell the day of the creation of this cosmos. Then how can one know the birthday of such Lord who is Ajuni (beyond birth) ? Thus worship of gods who are born and who die is futile. Worship of eternal Lord is only purposeful. (484)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/489.json
+++ b/data/Kabit Savaiye/489.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Significance and the ecstasy of True Guru blessed Naam Simran is beyond explanation. That is why all supplicate and salute Him saying repeatedly-Not this, Not this and Not even this.  (489)",
+              "translation": "Significance and the ecstasy of True Guru blessed Naam Simran is beyond explanation. That is why all supplicate and salute Him saying repeatedly-Not this, Not this and Not even this. (489)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/492.json
+++ b/data/Kabit Savaiye/492.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, there is much difference in the love of the Sikhs of the Guru and followers of gods and goddesses. True Guru is like ocean full of divine virtues whereas gods and goddesses are like rivers and brooks. Ocean and streams can never be alike.  (492",
+              "translation": "Similarly, there is much difference in the love of the Sikhs of the Guru and followers of gods and goddesses. True Guru is like ocean full of divine virtues whereas gods and goddesses are like rivers and brooks. Ocean and streams can never be alike. (492",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/493.json
+++ b/data/Kabit Savaiye/493.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The behaviour of Guru-conscious and self-conscious persons is like sandalwood and bamboo. Evil persons fight with others and destroy themselves as bamboos set themselves on fire. On the contrary, virtuous people are seen doing good to their companions.  (",
+              "translation": "The behaviour of Guru-conscious and self-conscious persons is like sandalwood and bamboo. Evil persons fight with others and destroy themselves as bamboos set themselves on fire. On the contrary, virtuous people are seen doing good to their companions. (",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/495.json
+++ b/data/Kabit Savaiye/495.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an ignorant man entangled in worldly love and attachments, spends his life accumulating wealth. How can he engross his mind in the name of the Lord when he is on his last breaths?  (495)",
+              "translation": "Similarly, an ignorant man entangled in worldly love and attachments, spends his life accumulating wealth. How can he engross his mind in the name of the Lord when he is on his last breaths? (495)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/496.json
+++ b/data/Kabit Savaiye/496.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So is the mind entangled in the darkness of mammon (maya). An ignorant mind cannot enjoy the unique bliss of the contemplation of True Guru and meditation on Lord's name.  (496)",
+              "translation": "So is the mind entangled in the darkness of mammon (maya). An ignorant mind cannot enjoy the unique bliss of the contemplation of True Guru and meditation on Lord's name. (496)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/497.json
+++ b/data/Kabit Savaiye/497.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an obedient Sikh of the Guru is a prince at one time and a supreme ascetic at another time. Even when he is wealthy, he still remains absorbed in the methods of realisation of the Lord.  (497)",
+              "translation": "Similarly, an obedient Sikh of the Guru is a prince at one time and a supreme ascetic at another time. Even when he is wealthy, he still remains absorbed in the methods of realisation of the Lord. (497)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/498.json
+++ b/data/Kabit Savaiye/498.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Therefore, O fellow being! the time of this life is passing by. You must win the game of life. Enjoin the holy gathering of saintly souls and develop your love for the infinite Lord.  (498)",
+              "translation": "Therefore, O fellow being! the time of this life is passing by. You must win the game of life. Enjoin the holy gathering of saintly souls and develop your love for the infinite Lord. (498)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/498.json
+++ b/data/Kabit Savaiye/498.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Therefore, 0 fellow being! the time of this life is passing by. You must win the game of life. Enjoin the holy gathering of saintly souls and develop your love for the infinite Lord.  (498)",
+              "translation": "Therefore, O fellow being! the time of this life is passing by. You must win the game of life. Enjoin the holy gathering of saintly souls and develop your love for the infinite Lord.  (498)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/499.json
+++ b/data/Kabit Savaiye/499.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Union with saintly congregation is blessed if it brings in a state of equipoise. The mind is blessed only when it imbibes the teachings of the True Guru.  (499)",
+              "translation": "Union with saintly congregation is blessed if it brings in a state of equipoise. The mind is blessed only when it imbibes the teachings of the True Guru. (499)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/500.json
+++ b/data/Kabit Savaiye/500.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "When will I get a chance to write the name of the Lord on the paper-like mind with the conscious-like ink? Therefore I should write the True Guru blessed word on the paper-like heart and reach the self-realisation (through constant meditation).  (500)",
+              "translation": "When will I get a chance to write the name of the Lord on the paper-like mind with the conscious-like ink? Therefore I should write the True Guru blessed word on the paper-like heart and reach the self-realisation (through constant meditation). (500)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/501.json
+++ b/data/Kabit Savaiye/501.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a congregation of saintly persons in the presence of True Guru is an assembly of swans where I, person of crow- like temperament indulging in singing of Gurbani not turned out and away.  (501)",
+              "translation": "Similarly, a congregation of saintly persons in the presence of True Guru is an assembly of swans where I, person of crow- like temperament indulging in singing of Gurbani not turned out and away. (501)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/502.json
+++ b/data/Kabit Savaiye/502.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a seeker living in the refuge of the True Guru remains oblivious of the greatness of Guru. But when separated from Him, repents and laments.  (502)",
+              "translation": "Similarly, a seeker living in the refuge of the True Guru remains oblivious of the greatness of Guru. But when separated from Him, repents and laments. (502)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/503.json
+++ b/data/Kabit Savaiye/503.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Because of my ill deeds, I cannot find a place even in hell. But I am leaning and depending upon your character of merciful, benevolent, clement, and corrector of the evil-doers.  (503)",
+              "translation": "Because of my ill deeds, I cannot find a place even in hell. But I am leaning and depending upon your character of merciful, benevolent, clement, and corrector of the evil-doers. (503)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/504.json
+++ b/data/Kabit Savaiye/504.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O store house of clemency! One. who does good to others begets good in returns. But doing good to low and evil doers like us behoves only You. (You alone can bless and forgive the sins and evil deeds of all).  (504)",
+              "translation": "O store house of clemency! One. who does good to others begets good in returns. But doing good to low and evil doers like us behoves only You. (You alone can bless and forgive the sins and evil deeds of all). (504)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/504.json
+++ b/data/Kabit Savaiye/504.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "If we have fallen from your favour due to our evil and unrighteous deeds, then 0 Lord! You have made known that You bless the sinners with Your grace and make them good and pious.",
+              "translation": "If we have fallen from your favour due to our evil and unrighteous deeds, then O Lord! You have made known that You bless the sinners with Your grace and make them good and pious.",
               "additional_information": {}
             }
           },
@@ -40,7 +40,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "If we are suffering due to our ill deeds and sins of the previous births, then 0 Lord! You have made it conspicuous that You dispel the sufferings of the poor and destitudes.",
+              "translation": "If we are suffering due to our ill deeds and sins of the previous births, then O Lord! You have made it conspicuous that You dispel the sufferings of the poor and destitudes.",
               "additional_information": {}
             }
           },
@@ -63,7 +63,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "If we are in the grip of the angels of death and become deserving of a life in hell because of our bad and evil deeds, then 0 Lord ! The whole world is singing Your paeans that You are the liberator of all from the vagaries of hell.",
+              "translation": "If we are in the grip of the angels of death and become deserving of a life in hell because of our bad and evil deeds, then O Lord ! The whole world is singing Your paeans that You are the liberator of all from the vagaries of hell.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/506.json
+++ b/data/Kabit Savaiye/506.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the vices and sins that one acquires by associating oneself with other's wealth and beauty, one loses the much valuable commodity of happiness, good deeds and peace.  (506)",
+              "translation": "Similarly, the vices and sins that one acquires by associating oneself with other's wealth and beauty, one loses the much valuable commodity of happiness, good deeds and peace. (506)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/507.json
+++ b/data/Kabit Savaiye/507.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, like bamboo, frog and heron, I am devoid of practicing Guru's teachings despite the fact that I live near my Guru. On the contrary Sikhs residing far off acquire Guru's wisdom and lodge it in their heart to practice on.  (507)",
+              "translation": "Similarly, like bamboo, frog and heron, I am devoid of practicing Guru's teachings despite the fact that I live near my Guru. On the contrary Sikhs residing far off acquire Guru's wisdom and lodge it in their heart to practice on. (507)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/509.json
+++ b/data/Kabit Savaiye/509.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly by associating themselves with the congregation of the True Guru, the whole world is sailing across the worldly ocean but I, the sinner is spending all his life in evil deeds and vices.  (509)",
+              "translation": "Similarly by associating themselves with the congregation of the True Guru, the whole world is sailing across the worldly ocean but I, the sinner is spending all his life in evil deeds and vices. (509)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/510.json
+++ b/data/Kabit Savaiye/510.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly if someone talks of knowledge and contemplations and pretends to surrender himself with a view to please and entice the True Guru, he cannot succeed in his nefarious designs of pleasing the True Guru the master of all life.  (510)",
+              "translation": "Similarly if someone talks of knowledge and contemplations and pretends to surrender himself with a view to please and entice the True Guru, he cannot succeed in his nefarious designs of pleasing the True Guru the master of all life. (510)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/511.json
+++ b/data/Kabit Savaiye/511.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly if someone tries to display his traits and knowledge before the True Guru who Himself is ocean of knowledge and divine traits, such a person will be called a fool.  (511)",
+              "translation": "Similarly if someone tries to display his traits and knowledge before the True Guru who Himself is ocean of knowledge and divine traits, such a person will be called a fool. (511)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/512.json
+++ b/data/Kabit Savaiye/512.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly sin-filled I, am a big sinner. The sin of slandering the whole world pleases me.  (512)",
+              "translation": "Similarly sin-filled I, am a big sinner. The sin of slandering the whole world pleases me. (512)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/513.json
+++ b/data/Kabit Savaiye/513.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly I am infested with three chronic ailments-namely other's women, other's wealth and slander. And that is why praise of the devoted and loving Sikhs of the True Guru does not please me.  (513)",
+              "translation": "Similarly I am infested with three chronic ailments-namely other's women, other's wealth and slander. And that is why praise of the devoted and loving Sikhs of the True Guru does not please me. (513)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/514.json
+++ b/data/Kabit Savaiye/514.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly separated from the saintly congregation of the True Guru, a Sikh of the Guru wails, tosses and turns, feels miserable and perplexed. Without the company of saintly souls of the True Guru, he has no other aim in life.  (514)",
+              "translation": "Similarly separated from the saintly congregation of the True Guru, a Sikh of the Guru wails, tosses and turns, feels miserable and perplexed. Without the company of saintly souls of the True Guru, he has no other aim in life. (514)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/515.json
+++ b/data/Kabit Savaiye/515.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly if a Sikh of the True Guru somehow get separated from his Guru, he remains invigorated by virtue of holy congregation, meditation on His name and contemplating and focusing his mind in the holy feet of his True Guru.  (515)",
+              "translation": "Similarly if a Sikh of the True Guru somehow get separated from his Guru, he remains invigorated by virtue of holy congregation, meditation on His name and contemplating and focusing his mind in the holy feet of his True Guru. (515)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/516.json
+++ b/data/Kabit Savaiye/516.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly without the boon of Lord's name given by the True Guru, God cannot be realised. And without Naam the liberator from the worldly desires and blessed by the True Guru, no one can acquire spiritual effulgence.  (516)",
+              "translation": "Similarly without the boon of Lord's name given by the True Guru, God cannot be realised. And without Naam the liberator from the worldly desires and blessed by the True Guru, no one can acquire spiritual effulgence. (516)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/517.json
+++ b/data/Kabit Savaiye/517.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly an ignorant person consumes the offerings made by the devotees of the True Guru. He suffers much at the time of his death. He has to face the wrath of the angels of death.  (517)",
+              "translation": "Similarly an ignorant person consumes the offerings made by the devotees of the True Guru. He suffers much at the time of his death. He has to face the wrath of the angels of death. (517)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/520.json
+++ b/data/Kabit Savaiye/520.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly a true disciple wants to enjoy the pleasures of the refuge of True Guru but bound by his command he wanders around dejectedly in another place.  (520)",
+              "translation": "Similarly a true disciple wants to enjoy the pleasures of the refuge of True Guru but bound by his command he wanders around dejectedly in another place. (520)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/521.json
+++ b/data/Kabit Savaiye/521.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Who is ungrateful, venomous and user of arrow-like sharp words, who is miserable due to countless sins, vices or imperfections; such countless evil-doers cannot match even a hair of my sins. I am many time more evil than them.  (521)",
+              "translation": "Who is ungrateful, venomous and user of arrow-like sharp words, who is miserable due to countless sins, vices or imperfections; such countless evil-doers cannot match even a hair of my sins. I am many time more evil than them. (521)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/523.json
+++ b/data/Kabit Savaiye/523.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly millions of sins are not even counterweight of my sins. But to punish me with abode in hell and entrusting me to the angels of death is showing mercy on me.  (523)",
+              "translation": "Similarly millions of sins are not even counterweight of my sins. But to punish me with abode in hell and entrusting me to the angels of death is showing mercy on me. (523)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/524.json
+++ b/data/Kabit Savaiye/524.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A thief, dacoit and a lecherous man is punished so severely for one crime they commit. But I am a sufferer of all these three ailments like tuberculosis. So punishing me for all these sins, the angels of death will get tired.  (524)",
+              "translation": "A thief, dacoit and a lecherous man is punished so severely for one crime they commit. But I am a sufferer of all these three ailments like tuberculosis. So punishing me for all these sins, the angels of death will get tired. (524)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/526.json
+++ b/data/Kabit Savaiye/526.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The ignorant world's perception is contrary (to the truth of Guru's words). The world slanders those who are disciplined, truthful, contented and supreme.  (526)",
+              "translation": "The ignorant world's perception is contrary (to the truth of Guru's words). The world slanders those who are disciplined, truthful, contented and supreme. (526)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/527.json
+++ b/data/Kabit Savaiye/527.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly O True Guru, You are an epitome of the all doing Lord and we are insignificant creation.   How can we speak before you?    (527)",
+              "translation": "Similarly O True Guru, You are an epitome of the all doing Lord and we are insignificant creation.   How can we speak before you?   (527)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/528.json
+++ b/data/Kabit Savaiye/528.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O  True Guru! there is no Master like You. But there is no one as dependent as I am. There is no one as great a donor as You and there is no beggar as needy as me.",
+              "translation": "O True Guru! there is no Master like You. But there is no one as dependent as I am. There is no one as great a donor as You and there is no beggar as needy as me.",
               "additional_information": {}
             }
           },
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "I am full of faults and demerits but You are an ocean of virtues. You are my refuge on my way to hell.  (528)",
+              "translation": "I am full of faults and demerits but You are an ocean of virtues. You are my refuge on my way to hell. (528)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/529.json
+++ b/data/Kabit Savaiye/529.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Kabit  - By practicing Naam Simran and breathing exercises, the fish-like sharp and wind-like fast blowing mind acquires a stable place beyond the tenth door which is inaccessible.",
+              "translation": "Kabit - By practicing Naam Simran and breathing exercises, the fish-like sharp and wind-like fast blowing mind acquires a stable place beyond the tenth door which is inaccessible.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/530.json
+++ b/data/Kabit Savaiye/530.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly many write Gur Shabad and Gurbani, sing and read it but. a rare person among them harbours loving desire of relishing and acquiring the divine elixir from it.  (530)",
+              "translation": "Similarly many write Gur Shabad and Gurbani, sing and read it but. a rare person among them harbours loving desire of relishing and acquiring the divine elixir from it. (530)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/532.json
+++ b/data/Kabit Savaiye/532.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "These are all the contrary moves of the dark age (Kalyug). The noble souls are suppressed while the culprits indulge in doing sins. (Vice and sins are rampant while noble souls are hiding themselves in this dark age).  (532)",
+              "translation": "These are all the contrary moves of the dark age (Kalyug). The noble souls are suppressed while the culprits indulge in doing sins. (Vice and sins are rampant while noble souls are hiding themselves in this dark age). (532)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/533.json
+++ b/data/Kabit Savaiye/533.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as without food and clothes a body cannot be kept healthy; similarly without the teachings and divine words obtainable from the True Guru, the wondrous elixir of Lord's love cannot be relished.  (533)",
+              "translation": "Just as without food and clothes a body cannot be kept healthy; similarly without the teachings and divine words obtainable from the True Guru, the wondrous elixir of Lord's love cannot be relished. (533)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/534.json
+++ b/data/Kabit Savaiye/534.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly the name of the Lord resides in True Guru and True Guru resides in His (Lord) name. He alone can understand this mystery of the Absolute God who has obtained knowledge from True Guru and who meditates on Him.  (534)",
+              "translation": "Similarly the name of the Lord resides in True Guru and True Guru resides in His (Lord) name. He alone can understand this mystery of the Absolute God who has obtained knowledge from True Guru and who meditates on Him. (534)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/535.json
+++ b/data/Kabit Savaiye/535.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if the sermon of the True Guru is practiced diligently, with love and devotion, with every breath, the Lord-God becomes conspicuously permeated in every living being.  (535)",
+              "translation": "Similarly, if the sermon of the True Guru is practiced diligently, with love and devotion, with every breath, the Lord-God becomes conspicuously permeated in every living being. (535)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/536.json
+++ b/data/Kabit Savaiye/536.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly the supreme benevolent True Guru does not dwell on any of the faults of His Sikhs. He is like touch of philosopher-stone (True Guru removes dross of the Sikhs in His refuge and makes them gold-like precious and pure).   (536)",
+              "translation": "Similarly the supreme benevolent True Guru does not dwell on any of the faults of His Sikhs. He is like touch of philosopher-stone (True Guru removes dross of the Sikhs in His refuge and makes them gold-like precious and pure).  (536)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/537.json
+++ b/data/Kabit Savaiye/537.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly without the company of saintly souls and devotees of the True Guru, the distress of repeated births and death cannot be wiped out. Nor can worldly fears and suspicions be destroyed without practicing on the sermon of the True Guru.  (537)",
+              "translation": "Similarly without the company of saintly souls and devotees of the True Guru, the distress of repeated births and death cannot be wiped out. Nor can worldly fears and suspicions be destroyed without practicing on the sermon of the True Guru. (537)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/538.json
+++ b/data/Kabit Savaiye/538.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly without taking refuge and consecration of True Guru, there is no other method or force that can end the repeated cycle of birth and death. One who is without the divine word of the Guru cannot be called a human being.  (538)",
+              "translation": "Similarly without taking refuge and consecration of True Guru, there is no other method or force that can end the repeated cycle of birth and death. One who is without the divine word of the Guru cannot be called a human being. (538)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/540.json
+++ b/data/Kabit Savaiye/540.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Jholana  - If all the 31 Simrities, 18 Purans, Bhagvad Geeta, four Vedas and their grammar become millions and speak,",
+              "translation": "Jholana - If all the 31 Simrities, 18 Purans, Bhagvad Geeta, four Vedas and their grammar become millions and speak,",
               "additional_information": {}
             }
           },
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O friend! all the above will fall woefully short of saying the praise of a syllable of the True Guru's blessed Naam Gur Mantar. The significance of Guru's words is beyond the extent of all knowledge.  (540)",
+              "translation": "O friend! all the above will fall woefully short of saying the praise of a syllable of the True Guru's blessed Naam Gur Mantar. The significance of Guru's words is beyond the extent of all knowledge. (540)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/541.json
+++ b/data/Kabit Savaiye/541.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A fool who is devoid of such limbs and appendages that provide him with knowledge of the True Guru and contemplation, True Guru-the maker of pious people out of sinners, bless them with such divine knowledge through Naam Simran.  (541)",
+              "translation": "A fool who is devoid of such limbs and appendages that provide him with knowledge of the True Guru and contemplation, True Guru-the maker of pious people out of sinners, bless them with such divine knowledge through Naam Simran. (541)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/542.json
+++ b/data/Kabit Savaiye/542.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly just repeatedly asking for a glimpse of True Guru, one cannot acquire contemplation of the True Guru. This is possible only when one engrosses oneself up to the soul in the ardent desire of a glimpse of the True Guru.  (542)",
+              "translation": "Similarly just repeatedly asking for a glimpse of True Guru, one cannot acquire contemplation of the True Guru. This is possible only when one engrosses oneself up to the soul in the ardent desire of a glimpse of the True Guru. (542)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/543.json
+++ b/data/Kabit Savaiye/543.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Such fortunate and enjoying the worldly maya are the Sikhs of the Guru who are seeing the inaccessible Lord in the manifested state of a True Guru.  (543)",
+              "translation": "Such fortunate and enjoying the worldly maya are the Sikhs of the Guru who are seeing the inaccessible Lord in the manifested state of a True Guru. (543)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/545.json
+++ b/data/Kabit Savaiye/545.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "In order to liberate oneself from the wandering and effect of the deeds performed, one takes the support of True Guru. And if even then the cycle of deeds and actions do not end, then whose refuge should be sought.  (545)",
+              "translation": "In order to liberate oneself from the wandering and effect of the deeds performed, one takes the support of True Guru. And if even then the cycle of deeds and actions do not end, then whose refuge should be sought. (545)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/546.json
+++ b/data/Kabit Savaiye/546.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly Gurbani has all the precious items but whosoever would search and research them, he would be rewarded with those items that he so fondly desires.  (546)",
+              "translation": "Similarly Gurbani has all the precious items but whosoever would search and research them, he would be rewarded with those items that he so fondly desires. (546)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/547.json
+++ b/data/Kabit Savaiye/547.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "By virtue of True Guru's sermon, keep the wandering of the mind in ten directions under control and abstain it from looking at other's woman, other's wealth and slander.  (547)",
+              "translation": "By virtue of True Guru's sermon, keep the wandering of the mind in ten directions under control and abstain it from looking at other's woman, other's wealth and slander. (547)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/549.json
+++ b/data/Kabit Savaiye/549.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly someone's company liberates, while other's company leads one to hell.  (549)",
+              "translation": "Similarly someone's company liberates, while other's company leads one to hell. (549)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/550.json
+++ b/data/Kabit Savaiye/550.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The disciple who is able to engross his mind in the divine word, and yet separates himself from True Guru, his love is false. He cannot be called a true lover.  (550)",
+              "translation": "The disciple who is able to engross his mind in the divine word, and yet separates himself from True Guru, his love is false. He cannot be called a true lover. (550)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/551.json
+++ b/data/Kabit Savaiye/551.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A devoted disciple of the True Guru engrosses his mind in the divine word, practices it and swims in the loving lap of the True Guru as a fish swims in water merrily and contented.  (551)",
+              "translation": "A devoted disciple of the True Guru engrosses his mind in the divine word, practices it and swims in the loving lap of the True Guru as a fish swims in water merrily and contented. (551)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/553.json
+++ b/data/Kabit Savaiye/553.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Everyone says that no salvation can be achieved without a Guru, but one requires such a capable True Guru who can guide a person to salvation through His advice while living a householder's life, in a society and enjoying all material comforts.  (553)",
+              "translation": "Everyone says that no salvation can be achieved without a Guru, but one requires such a capable True Guru who can guide a person to salvation through His advice while living a householder's life, in a society and enjoying all material comforts. (553)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/554.json
+++ b/data/Kabit Savaiye/554.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The True Guru who is engrossed in such God is absorbed and permeated in the congregation of supreme people. O brother! I fall, yes I fall on the holy feet of such a True Guru.  (554)",
+              "translation": "The True Guru who is engrossed in such God is absorbed and permeated in the congregation of supreme people. O brother! I fall, yes I fall on the holy feet of such a True Guru. (554)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/554.json
+++ b/data/Kabit Savaiye/554.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The True Guru who is engrossed in such God is absorbed and permeated in the congregation of supreme people. 0 brother! I fall, yes I fall on the holy feet of such a True Guru.  (554)",
+              "translation": "The True Guru who is engrossed in such God is absorbed and permeated in the congregation of supreme people. O brother! I fall, yes I fall on the holy feet of such a True Guru.  (554)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/555.json
+++ b/data/Kabit Savaiye/555.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly an ignorant and foolish person indulges in umpteen sins, collects wealth and leaves this world empty-handed. (All his earnings and material goods prove worthless ultimately).  (555)",
+              "translation": "Similarly an ignorant and foolish person indulges in umpteen sins, collects wealth and leaves this world empty-handed. (All his earnings and material goods prove worthless ultimately). (555)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/556.json
+++ b/data/Kabit Savaiye/556.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Ignorant and foolish devotees call it His praise. Infact they are slandering the Lord. It is better to remain silent rather than say such praises.  (556)",
+              "translation": "Ignorant and foolish devotees call it His praise. Infact they are slandering the Lord. It is better to remain silent rather than say such praises. (556)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/557.json
+++ b/data/Kabit Savaiye/557.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly by listening to True Guru's word and meditating on it, all the effects of worldly vices and attachment are eliminated. (All the influence of worldly things (Maya) ends.)  (557)",
+              "translation": "Similarly by listening to True Guru's word and meditating on it, all the effects of worldly vices and attachment are eliminated. (All the influence of worldly things (Maya) ends.) (557)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/558.json
+++ b/data/Kabit Savaiye/558.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, pain and sufferings are unbearable and leave a person in an unstable state. But with the advice and initiation of a True Guru, all pain and sufferings are washed away and one becomes quiet, calm and composed.  (558)",
+              "translation": "Similarly, pain and sufferings are unbearable and leave a person in an unstable state. But with the advice and initiation of a True Guru, all pain and sufferings are washed away and one becomes quiet, calm and composed. (558)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/559.json
+++ b/data/Kabit Savaiye/559.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, faithful and obedient disciple get together in a Dharamsala and by contemplating on His elixir-like name feel happy and satisfied.  (559)",
+              "translation": "Similarly, faithful and obedient disciple get together in a Dharamsala and by contemplating on His elixir-like name feel happy and satisfied. (559)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/561.json
+++ b/data/Kabit Savaiye/561.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly death-like snake is swallowing everyone. But once consecration from the Guru in the form of Naam is obtained, then the angel of death becomes slave of the slaves.  (561)",
+              "translation": "Similarly death-like snake is swallowing everyone. But once consecration from the Guru in the form of Naam is obtained, then the angel of death becomes slave of the slaves. (561)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/563.json
+++ b/data/Kabit Savaiye/563.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a Sikh of the Guru whether new or old devotee who gets a look of grace of the True Guru, earns honour, glory and praise.  (563)",
+              "translation": "Similarly, a Sikh of the Guru whether new or old devotee who gets a look of grace of the True Guru, earns honour, glory and praise. (563)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/567.json
+++ b/data/Kabit Savaiye/567.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, seeing the listeners sitting in singular mind, the singers sing the divine hymns in deep devotion and attention that creates an atmosphere of loving tranquility absorbing both the singers and the listeners in divine state of ecstasy.  (567)",
+              "translation": "Similarly, seeing the listeners sitting in singular mind, the singers sing the divine hymns in deep devotion and attention that creates an atmosphere of loving tranquility absorbing both the singers and the listeners in divine state of ecstasy. (567)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/568.json
+++ b/data/Kabit Savaiye/568.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an obedient disciple of the True Guru absorbs himself in the meditation of the Lord's name and feels satiated and blissful relishing the elixir like Naam. (But he does not mention his blissful state of the ambrosial hour to anyone).  (568)",
+              "translation": "Similarly, an obedient disciple of the True Guru absorbs himself in the meditation of the Lord's name and feels satiated and blissful relishing the elixir like Naam. (But he does not mention his blissful state of the ambrosial hour to anyone). (568)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/570.json
+++ b/data/Kabit Savaiye/570.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a true Sikh of the True Guru recognises which composition is fake and which one is genuine, created by the True Guru as soon as he hears it. He discards what is not genuine in no time and keeps it in no account.  (570)",
+              "translation": "Similarly, a true Sikh of the True Guru recognises which composition is fake and which one is genuine, created by the True Guru as soon as he hears it. He discards what is not genuine in no time and keeps it in no account. (570)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/571.json
+++ b/data/Kabit Savaiye/571.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "I am sacrifice unto you 0 Crow! go and convey my message to my beloved to come and meet me soon so as to allay my sufferings, distresses and pangs of separation;",
+              "translation": "I am sacrifice unto you O Crow! go and convey my message to my beloved to come and meet me soon so as to allay my sufferings, distresses and pangs of separation;",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/571.json
+++ b/data/Kabit Savaiye/571.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O my dear beloved! much delay has taken place in meeting with You and I am very anxious and impatient to meet You. I can hold on to my patience no more. Should I then dress up as a (female) yogi and search You?  (571)",
+              "translation": "O my dear beloved! much delay has taken place in meeting with You and I am very anxious and impatient to meet You. I can hold on to my patience no more. Should I then dress up as a (female) yogi and search You? (571)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/572.json
+++ b/data/Kabit Savaiye/572.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "All the pains of the world put together cannot reach the pain of separation of the Lord even for a moment. (All worldly distresses are trivial compared to the pangs of separation of the Lord).   (572)",
+              "translation": "All the pains of the world put together cannot reach the pain of separation of the Lord even for a moment. (All worldly distresses are trivial compared to the pangs of separation of the Lord).  (572)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/573.json
+++ b/data/Kabit Savaiye/573.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Separation of the beloved Lord has made both living life and death burdensome. I must have made a blunder in abiding by the vows and promises of love that I had made that is sullying my human birth. (The life is going to waste).  (573)",
+              "translation": "Separation of the beloved Lord has made both living life and death burdensome. I must have made a blunder in abiding by the vows and promises of love that I had made that is sullying my human birth. (The life is going to waste). (573)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/574.json
+++ b/data/Kabit Savaiye/574.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as a fish has no other aim than living in the company of its beloved water, I have no other purpose of life than living with my beloved Lord.  (574)",
+              "translation": "Just as a fish has no other aim than living in the company of its beloved water, I have no other purpose of life than living with my beloved Lord. (574)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/575.json
+++ b/data/Kabit Savaiye/575.json
@@ -63,7 +63,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Then, when the beloved Lord himself used to come and call me-O darling! 0 dear one! I used to keep silent just to feel important.",
+              "translation": "Then, when the beloved Lord himself used to come and call me-O darling! O dear one! I used to keep silent just to feel important.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/575.json
+++ b/data/Kabit Savaiye/575.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "And now when I am suffering the pangs of separation of my husband, no one even come to ask me what state I am living in. Standing on my beloved's door I am crying and wailing.  (575)",
+              "translation": "And now when I am suffering the pangs of separation of my husband, no one even come to ask me what state I am living in. Standing on my beloved's door I am crying and wailing. (575)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/576.json
+++ b/data/Kabit Savaiye/576.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "But now on separation, I lament and cry with the same forehead, but my beloved master does not even appear in my dreams.  (576)",
+              "translation": "But now on separation, I lament and cry with the same forehead, but my beloved master does not even appear in my dreams. (576)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/577.json
+++ b/data/Kabit Savaiye/577.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a sinful man wants to leave his evil deeds because of pain and sufferings that these have caused him but as soon as the sentenced punishment period is over, re-indulges in these vices.  (577)",
+              "translation": "Similarly, a sinful man wants to leave his evil deeds because of pain and sufferings that these have caused him but as soon as the sentenced punishment period is over, re-indulges in these vices. (577)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/578.json
+++ b/data/Kabit Savaiye/578.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, wandering in the country and beyond, I have spent my life in a dream. I have not been able to reach where I had to go. (I have failed to re-unite myself with God).  (578)",
+              "translation": "Similarly, wandering in the country and beyond, I have spent my life in a dream. I have not been able to reach where I had to go. (I have failed to re-unite myself with God). (578)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/579.json
+++ b/data/Kabit Savaiye/579.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Like a performer of strange acts, the beloved master is existing in strange form both in and out of the bodies. He is present in all bodies and yet is separate from all.  (579)",
+              "translation": "Like a performer of strange acts, the beloved master is existing in strange form both in and out of the bodies. He is present in all bodies and yet is separate from all. (579)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/581.json
+++ b/data/Kabit Savaiye/581.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, those who took consecration from the True Guru and practiced Naam Simran to discipline their minds become superior persons. They are the emancipator of the whole world by attaching them with Guru.  (581)",
+              "translation": "Similarly, those who took consecration from the True Guru and practiced Naam Simran to discipline their minds become superior persons. They are the emancipator of the whole world by attaching them with Guru. (581)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/583.json
+++ b/data/Kabit Savaiye/583.json
@@ -63,7 +63,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as several passengers travel in a boat, but all of them have different destinations. Everyone goes his own way 00 leaving the boat.",
+              "translation": "Just as several passengers travel in a boat, but all of them have different destinations. Everyone goes his own way on leaving the boat.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/583.json
+++ b/data/Kabit Savaiye/583.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, several Sikhs of different aptitude take refuge of the True Guru, but the cause of all causes--the capable True Guru makes them alike by bestowing on them the elixir of Naam.  (583)",
+              "translation": "Similarly, several Sikhs of different aptitude take refuge of the True Guru, but the cause of all causes--the capable True Guru makes them alike by bestowing on them the elixir of Naam. (583)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/584.json
+++ b/data/Kabit Savaiye/584.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, falling in the refuge of the True Guru, one surrenders all (body, mind and wealth) to Him. Then obtaining the incantation of Naam from the True Guru, one achieves emancipation and is freed from repeated deaths and births.  (584)",
+              "translation": "Similarly, falling in the refuge of the True Guru, one surrenders all (body, mind and wealth) to Him. Then obtaining the incantation of Naam from the True Guru, one achieves emancipation and is freed from repeated deaths and births. (584)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/585.json
+++ b/data/Kabit Savaiye/585.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, one cannot obtain the wisdom of True Guru by just hearing or saying unless the skill of practicing devotedly the Gurus' words obtained from the True Guru is known.  (585)",
+              "translation": "Similarly, one cannot obtain the wisdom of True Guru by just hearing or saying unless the skill of practicing devotedly the Gurus' words obtained from the True Guru is known. (585)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/586.json
+++ b/data/Kabit Savaiye/586.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the Supreme Lord is residing completely in everyone's heart but He can be realised only by taking the refuge of True Guru and great souls.  (586)",
+              "translation": "Similarly, the Supreme Lord is residing completely in everyone's heart but He can be realised only by taking the refuge of True Guru and great souls. (586)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/590.json
+++ b/data/Kabit Savaiye/590.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a seeker perpetually dives in Gurbani, but some day he becomes so engrossed in Gurbani that he is absorbed in Guru's words.  (590)",
+              "translation": "Similarly, a seeker perpetually dives in Gurbani, but some day he becomes so engrossed in Gurbani that he is absorbed in Guru's words. (590)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/591.json
+++ b/data/Kabit Savaiye/591.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as all humans declare mammon (maya) a troublesome necessity, yet it cannot be won over by anyone. On the contrary, it is plundering the whole world. (It is entangling people in its net and taking them away from the holy feet of the Lord.)  (591)",
+              "translation": "Just as all humans declare mammon (maya) a troublesome necessity, yet it cannot be won over by anyone. On the contrary, it is plundering the whole world. (It is entangling people in its net and taking them away from the holy feet of the Lord.) (591)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/594.json
+++ b/data/Kabit Savaiye/594.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A seeker woman whom He likes, all efforts and labour bear fruit. Her grandeur is beyond and difficult to express.  (594)",
+              "translation": "A seeker woman whom He likes, all efforts and labour bear fruit. Her grandeur is beyond and difficult to express. (594)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/595.json
+++ b/data/Kabit Savaiye/595.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, no one should be praised or slandered before time. Who knows what sort of a day may dawn in the end that all his labour may bear fruit or not. (One may tread a wrong path and wander or will be accepted by the Guru ultimately).  (595)",
+              "translation": "Similarly, no one should be praised or slandered before time. Who knows what sort of a day may dawn in the end that all his labour may bear fruit or not. (One may tread a wrong path and wander or will be accepted by the Guru ultimately). (595)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/596.json
+++ b/data/Kabit Savaiye/596.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, outer signs of a real and a fake saint look alike but their actions and characteristics can reveal who is genuine among them. (Only then can one know who is good and who is bad).  (596)",
+              "translation": "Similarly, outer signs of a real and a fake saint look alike but their actions and characteristics can reveal who is genuine among them. (Only then can one know who is good and who is bad). (596)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/598.json
+++ b/data/Kabit Savaiye/598.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a human soul under the influence of good and bad company and developing love and attachment with consciousless maya becomes consciousless. And by loving the conscious benevolent Lord, it also becomes benevolent and conscientious.  (598)",
+              "translation": "Similarly, a human soul under the influence of good and bad company and developing love and attachment with consciousless maya becomes consciousless. And by loving the conscious benevolent Lord, it also becomes benevolent and conscientious. (598)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/599.json
+++ b/data/Kabit Savaiye/599.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a Guru-conscious and Guru aware person remains engrossed in the elixir-like name of the Lord blessed by the True Guru. (Practicing of Naam becomes then his life's support).  (599)",
+              "translation": "Similarly, a Guru-conscious and Guru aware person remains engrossed in the elixir-like name of the Lord blessed by the True Guru. (Practicing of Naam becomes then his life's support). (599)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/600.json
+++ b/data/Kabit Savaiye/600.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, I who is low and wear a hypocrite garb have not appreciated the value of the words of True Guru which are priceless treasure for fulfilling the pledges and promises of love.  (600)",
+              "translation": "Similarly, I who is low and wear a hypocrite garb have not appreciated the value of the words of True Guru which are priceless treasure for fulfilling the pledges and promises of love. (600)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/601.json
+++ b/data/Kabit Savaiye/601.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O  Lord! what is that worship that has made You the beloved of the worshippers? Which is that apostasy that has made You the forgiver and purifier of the sinners?",
+              "translation": "O Lord! what is that worship that has made You the beloved of the worshippers? Which is that apostasy that has made You the forgiver and purifier of the sinners?",
               "additional_information": {}
             }
           },
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O my Lord! I have not been able to fathom Your duty and nature. Please be kind and tell me by what form of worship and service that can bring humility in me, destroy my ego and apostasy, can I reach you?  (601)",
+              "translation": "O my Lord! I have not been able to fathom Your duty and nature. Please be kind and tell me by what form of worship and service that can bring humility in me, destroy my ego and apostasy, can I reach you? (601)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/602.json
+++ b/data/Kabit Savaiye/602.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The Lord who has the mind, body, wealth and the world in His control, involvement in whose praise one becomes adorable; how can such a Lord be brought in one's favour?  (602)",
+              "translation": "The Lord who has the mind, body, wealth and the world in His control, involvement in whose praise one becomes adorable; how can such a Lord be brought in one's favour? (602)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/603.json
+++ b/data/Kabit Savaiye/603.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, engrossed in maya and liberated of maya's influence are two tendencies in the world. But whatever intentions and inclinations one goes to the True Guru, he acquires the trait of worldly or divinely accordingly.  (603)",
+              "translation": "Similarly, engrossed in maya and liberated of maya's influence are two tendencies in the world. But whatever intentions and inclinations one goes to the True Guru, he acquires the trait of worldly or divinely accordingly. (603)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/605.json
+++ b/data/Kabit Savaiye/605.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an obedient disciple of True Guru who experiences light divine as a result of his loving, perpetual meditation on Naam blessed by the Guru, he earns much respect and praise whether he speaks in a detached mood or goes silent in ecstasy.  (605)",
+              "translation": "Similarly, an obedient disciple of True Guru who experiences light divine as a result of his loving, perpetual meditation on Naam blessed by the Guru, he earns much respect and praise whether he speaks in a detached mood or goes silent in ecstasy. (605)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/606.json
+++ b/data/Kabit Savaiye/606.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an obedient Sikh who is accepted (by the Guru) and in whose mind the words and knowledge of the True Guru the supreme treasure, gets lodged, that Sikh's feet are bowed at by the whole world.  (606)",
+              "translation": "Similarly, an obedient Sikh who is accepted (by the Guru) and in whose mind the words and knowledge of the True Guru the supreme treasure, gets lodged, that Sikh's feet are bowed at by the whole world. (606)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/607.json
+++ b/data/Kabit Savaiye/607.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The Lord dearest than life is not captured or overpowered by controlling or giving up the use of senses or any other efforts. He can only be reached by meditating upon the words of the True Guru.  (607)",
+              "translation": "The Lord dearest than life is not captured or overpowered by controlling or giving up the use of senses or any other efforts. He can only be reached by meditating upon the words of the True Guru. (607)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/608.json
+++ b/data/Kabit Savaiye/608.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the True Guru has word (Naam) and True Guru resides in it. The True Guru alone explains us the focusing of mind on the absolute and transcendental form of divine knowledge.  (608)",
+              "translation": "Similarly, the True Guru has word (Naam) and True Guru resides in it. The True Guru alone explains us the focusing of mind on the absolute and transcendental form of divine knowledge. (608)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/609.json
+++ b/data/Kabit Savaiye/609.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, if the precept of the True Guru when practiced devotedly and lovingly with every breath, then the perfect Lord becomes imminent in His splendour in everybody and all forms.  (609)",
+              "translation": "Similarly, if the precept of the True Guru when practiced devotedly and lovingly with every breath, then the perfect Lord becomes imminent in His splendour in everybody and all forms. (609)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/610.json
+++ b/data/Kabit Savaiye/610.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an individual keeps wandering on this Earth according to the deeds that he had performed (in previous birth). He goes where he is destined to sustain himself.  (610)",
+              "translation": "Similarly, an individual keeps wandering on this Earth according to the deeds that he had performed (in previous birth). He goes where he is destined to sustain himself. (610)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/612.json
+++ b/data/Kabit Savaiye/612.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A momentary glimpse of grace by the True Guru provides a slave Sikh with all the bliss, ecstasy, happiness and millions of radiances, who has been blessed with consecration of Lord's name by the Guru.  (612)",
+              "translation": "A momentary glimpse of grace by the True Guru provides a slave Sikh with all the bliss, ecstasy, happiness and millions of radiances, who has been blessed with consecration of Lord's name by the Guru. (612)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/614.json
+++ b/data/Kabit Savaiye/614.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, the True Guru makes His Sikhs aware of the troublesome ailments and destroys the dross of maya with His knowledge, words and Naam, and then makes them aware of their self.  (614)",
+              "translation": "Similarly, the True Guru makes His Sikhs aware of the troublesome ailments and destroys the dross of maya with His knowledge, words and Naam, and then makes them aware of their self. (614)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/615.json
+++ b/data/Kabit Savaiye/615.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as hair and nails if plucked from their actual place are very uncomfortable and painful, such is the state of a woman separated from love of her husband.  (615)",
+              "translation": "Just as hair and nails if plucked from their actual place are very uncomfortable and painful, such is the state of a woman separated from love of her husband. (615)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/617.json
+++ b/data/Kabit Savaiye/617.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a traveller of the path of devotion and worship becomes consciously one with the master of the world. He either becomes totally silent or singing His praises and paeans, remains in a state of ecstasy.  (617)",
+              "translation": "Similarly, a traveller of the path of devotion and worship becomes consciously one with the master of the world. He either becomes totally silent or singing His praises and paeans, remains in a state of ecstasy. (617)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/619.json
+++ b/data/Kabit Savaiye/619.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "All those human beings who take refuge on the door of the king of kings, they enjoy the wondrous comforts of the treasure of Name and becomes liberated while alive. Such wondrous beauty of the court of the True Guru is becoming well adorned.  (619)",
+              "translation": "All those human beings who take refuge on the door of the king of kings, they enjoy the wondrous comforts of the treasure of Name and becomes liberated while alive. Such wondrous beauty of the court of the True Guru is becoming well adorned. (619)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/620.json
+++ b/data/Kabit Savaiye/620.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as many rivers fall in the sea and yet its thirst is never satiated. So is the love of his dear beloved in the heart of Gursikh where multi-waves of Naam are propagating yet its loving thirst is never satiated.  (620)",
+              "translation": "Just as many rivers fall in the sea and yet its thirst is never satiated. So is the love of his dear beloved in the heart of Gursikh where multi-waves of Naam are propagating yet its loving thirst is never satiated. (620)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/622.json
+++ b/data/Kabit Savaiye/622.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O my Great True Guru! Be clement on me and reside in my heart for ever. Please stop my wandering mind going all over and then engross it in high spiritual state.  (622)",
+              "translation": "O my Great True Guru! Be clement on me and reside in my heart for ever. Please stop my wandering mind going all over and then engross it in high spiritual state. (622)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/623.json
+++ b/data/Kabit Savaiye/623.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "What is the nature of lust, anger, greed, attachment and pride? Similarly reality of truth, contentment, kindness and righteousness cannot be known.  (623)",
+              "translation": "What is the nature of lust, anger, greed, attachment and pride? Similarly reality of truth, contentment, kindness and righteousness cannot be known. (623)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/624.json
+++ b/data/Kabit Savaiye/624.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The effulgent Lord is beyond comprehension. No one can know His secret. He is the cause of all happenings. He alone knows the secret of all these things. So it is futile for us to make any statement in connection with creation of Universe.  (624)",
+              "translation": "The effulgent Lord is beyond comprehension. No one can know His secret. He is the cause of all happenings. He alone knows the secret of all these things. So it is futile for us to make any statement in connection with creation of Universe. (624)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/626.json
+++ b/data/Kabit Savaiye/626.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "What dress and diamond can be worn to entice Him? With what method can the union of the beloved be relished? The crux of the whole thing is that all embellishments are worthless. Relishing His love can only unite one with Him.  (626)",
+              "translation": "What dress and diamond can be worn to entice Him? With what method can the union of the beloved be relished? The crux of the whole thing is that all embellishments are worthless. Relishing His love can only unite one with Him. (626)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/627.json
+++ b/data/Kabit Savaiye/627.json
@@ -40,7 +40,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O Priest, 0 astrologer! tell me of an auspicious day according to vedas.",
+              "translation": "O Priest, O astrologer! tell me of an auspicious day according to vedas.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/628.json
+++ b/data/Kabit Savaiye/628.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O True Guru! enlighten in me the loving respect by Your grace, making me dependent upon those holy and noble souls whose support is Lord's name. Grant me their company and food of loving devotion to survive on.  (628)",
+              "translation": "O True Guru! enlighten in me the loving respect by Your grace, making me dependent upon those holy and noble souls whose support is Lord's name. Grant me their company and food of loving devotion to survive on. (628)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/631.json
+++ b/data/Kabit Savaiye/631.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, without the teachings of True Guru, arrogant, cleverness is condemnable. Loud singing, playing or recitation of such a person is meaningless.  (631)",
+              "translation": "Similarly, without the teachings of True Guru, arrogant, cleverness is condemnable. Loud singing, playing or recitation of such a person is meaningless. (631)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/633.json
+++ b/data/Kabit Savaiye/633.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, without obtaining true precept from the True Guru, sin resides in the mind of a mammon-effected human being. This sin increases further if not controlled.  (633)",
+              "translation": "Similarly, without obtaining true precept from the True Guru, sin resides in the mind of a mammon-effected human being. This sin increases further if not controlled. (633)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/634.json
+++ b/data/Kabit Savaiye/634.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, without meeting the God-like True Guru, and keeping company of base people, one acquires base wisdom that becomes the cause of his falling in the hands of angels of death.  (634)",
+              "translation": "Similarly, without meeting the God-like True Guru, and keeping company of base people, one acquires base wisdom that becomes the cause of his falling in the hands of angels of death. (634)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/635.json
+++ b/data/Kabit Savaiye/635.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, a man may dress himself in any number of disguises and wander the world over. Even then he cannot acquire the radiance of knowledge without the initiation of the True Guru and receiving His precept.  (635)",
+              "translation": "Similarly, a man may dress himself in any number of disguises and wander the world over. Even then he cannot acquire the radiance of knowledge without the initiation of the True Guru and receiving His precept. (635)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/636.json
+++ b/data/Kabit Savaiye/636.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, an immoral person dies before his death by indulging in unrighteous deeds. And when he reaches Yamlok (abode of angels of death), he bears more punishment and pain.  (636)",
+              "translation": "Similarly, an immoral person dies before his death by indulging in unrighteous deeds. And when he reaches Yamlok (abode of angels of death), he bears more punishment and pain. (636)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/637.json
+++ b/data/Kabit Savaiye/637.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, one should maintain disciplined life and piety of actions. But, if even a small sin is committed, it is like a dreadful fire in a bail of cotton. (One small wrong act destroys all the goodness that had been earned.)  (637)",
+              "translation": "Similarly, one should maintain disciplined life and piety of actions. But, if even a small sin is committed, it is like a dreadful fire in a bail of cotton. (One small wrong act destroys all the goodness that had been earned.) (637)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/640.json
+++ b/data/Kabit Savaiye/640.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "I do not have the temperament of service in my heart; so I cannot reach for the service of my beloved. Nor do I have that devotion through which I can become one with the greatness of the dear Lord. (The greatness of the Lord may reside in me.)  (640)",
+              "translation": "I do not have the temperament of service in my heart; so I cannot reach for the service of my beloved. Nor do I have that devotion through which I can become one with the greatness of the dear Lord. (The greatness of the Lord may reside in me.) (640)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/645.json
+++ b/data/Kabit Savaiye/645.json
@@ -17,7 +17,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as a rain-bird longing for a Swati drop keep wailing making sound of  ' Peeu, Peeu' similarly a faithful wife fulfills her wifely duties remembering her husband,",
+              "translation": "Just as a rain-bird longing for a Swati drop keep wailing making sound of ' Peeu, Peeu' similarly a faithful wife fulfills her wifely duties remembering her husband,",
               "additional_information": {}
             }
           },
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "A separated faithful, loving and devoted wife who lives her life according to her religion is perhaps one in a billion.  (645)",
+              "translation": "A separated faithful, loving and devoted wife who lives her life according to her religion is perhaps one in a billion. (645)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/646.json
+++ b/data/Kabit Savaiye/646.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "No one can reach the glory and loving elixir of the True Guru. I sacrifice my body, mind and wealth unto Him.  (646)",
+              "translation": "No one can reach the glory and loving elixir of the True Guru. I sacrifice my body, mind and wealth unto Him. (646)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/647.json
+++ b/data/Kabit Savaiye/647.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "God who has not been realised by gods, man and Naths who have laboured untiringly, what type of love has made Him search you?  (647)",
+              "translation": "God who has not been realised by gods, man and Naths who have laboured untiringly, what type of love has made Him search you? (647)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/648.json
+++ b/data/Kabit Savaiye/648.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The Lord whose every aspect is so amazing, wondrous and beyond comprehension, how have you lodged Him in your heart who is infinite and without form?  (648)",
+              "translation": "The Lord whose every aspect is so amazing, wondrous and beyond comprehension, how have you lodged Him in your heart who is infinite and without form? (648)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/649.json
+++ b/data/Kabit Savaiye/649.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "How have you become the mistress of the Master of millions of Universes? How has He bestowed the happiness of all the realms to you ?  (649)",
+              "translation": "How have you become the mistress of the Master of millions of Universes? How has He bestowed the happiness of all the realms to you ? (649)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/650.json
+++ b/data/Kabit Savaiye/650.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Who is looked at with even a small look of grace by the Lord for her living a life commensurate with her feminine religion and duties.  (650)",
+              "translation": "Who is looked at with even a small look of grace by the Lord for her living a life commensurate with her feminine religion and duties. (650)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/651.json
+++ b/data/Kabit Savaiye/651.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Millions of four desirable elements (dharam, arth, kaam and mokh) cannot reach him who has been blessed with His Naam and who gets an opportunity of the auspicious invitation of the Master calling the seeker on the nuptial bed of His heart.  (651)",
+              "translation": "Millions of four desirable elements (dharam, arth, kaam and mokh) cannot reach him who has been blessed with His Naam and who gets an opportunity of the auspicious invitation of the Master calling the seeker on the nuptial bed of His heart. (651)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/652.json
+++ b/data/Kabit Savaiye/652.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Lord's name that makes dharam, arth, kaam and mokh as no more desirable elements of pursuits; the meditation of that Naam has enamored my beloved Lord in the hue of my love who has now come and taken the seat on my bed-like heart.  (652)",
+              "translation": "Lord's name that makes dharam, arth, kaam and mokh as no more desirable elements of pursuits; the meditation of that Naam has enamored my beloved Lord in the hue of my love who has now come and taken the seat on my bed-like heart. (652)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/653.json
+++ b/data/Kabit Savaiye/653.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Bless me that this desire and enthusiasm of my heart becomes fourfold. May the love within me become more powerful and unbearable and the benevolence of the beloved effulgent Lord appear ten times more for me.  (653)",
+              "translation": "Bless me that this desire and enthusiasm of my heart becomes fourfold. May the love within me become more powerful and unbearable and the benevolence of the beloved effulgent Lord appear ten times more for me. (653)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/655.json
+++ b/data/Kabit Savaiye/655.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as the beloved master is adept in the art of love, so is the strange and astonishing amorous feelings and love of the beloved seeker.  (655)",
+              "translation": "Just as the beloved master is adept in the art of love, so is the strange and astonishing amorous feelings and love of the beloved seeker. (655)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/656.json
+++ b/data/Kabit Savaiye/656.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The love-lorn beloved who is blessed with the task of sprinkling of water, grinding of mill-stone and filling of water, to state her praise, comfort and peace is beyond description.  (656)",
+              "translation": "The love-lorn beloved who is blessed with the task of sprinkling of water, grinding of mill-stone and filling of water, to state her praise, comfort and peace is beyond description. (656)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/657.json
+++ b/data/Kabit Savaiye/657.json
@@ -40,7 +40,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "As the water clock sinks repeatedly, 0 human being! you are also sinking your boat of life with ever increasing sins.",
+              "translation": "As the water clock sinks repeatedly, O human being! you are also sinking your boat of life with ever increasing sins.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/658.json
+++ b/data/Kabit Savaiye/658.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "But losing this opportunity of favourable constellation position for a union with God in the sleep of hateful ignorance, one will only repent when one wakes up (because by then it would be too late).  (658)",
+              "translation": "But losing this opportunity of favourable constellation position for a union with God in the sleep of hateful ignorance, one will only repent when one wakes up (because by then it would be too late). (658)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/659.json
+++ b/data/Kabit Savaiye/659.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O dear friend! I pray to you to be wise and understand this important fact, that she alone is supreme seeker female, who becomes dejure owner of her Lord's love and, ultimately becomes His beloved.  (659)",
+              "translation": "O dear friend! I pray to you to be wise and understand this important fact, that she alone is supreme seeker female, who becomes dejure owner of her Lord's love and, ultimately becomes His beloved. (659)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/660.json
+++ b/data/Kabit Savaiye/660.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "And if you fail to achieve union with your master Lord in this human birth, you will not get another opportunity. You will have to spend the remainder life in the separation of the Lord. The separation is far more painful than death.  (660)",
+              "translation": "And if you fail to achieve union with your master Lord in this human birth, you will not get another opportunity. You will have to spend the remainder life in the separation of the Lord. The separation is far more painful than death. (660)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/662.json
+++ b/data/Kabit Savaiye/662.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly, to be the wife of the ocean of kindness-dear Lord, one has to sacrifice oneself and become a living dead person. Only then can one acquire the treasure of all treasures (God's name from the True Guru) and reach the supreme divine state.  (662)",
+              "translation": "Similarly, to be the wife of the ocean of kindness-dear Lord, one has to sacrifice oneself and become a living dead person. Only then can one acquire the treasure of all treasures (God's name from the True Guru) and reach the supreme divine state. (662)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/663.json
+++ b/data/Kabit Savaiye/663.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O friend beloved of my Lord! do me a favour and bring around my separated Lord husband. And for such a favour, I will sacrifice all that I have many times over you.  (663)",
+              "translation": "O friend beloved of my Lord! do me a favour and bring around my separated Lord husband. And for such a favour, I will sacrifice all that I have many times over you. (663)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/664.json
+++ b/data/Kabit Savaiye/664.json
@@ -40,7 +40,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Due to my involvement in worldly pleasures, my Master beloved Lord has become angry with me. Now when I try to bring him around, I fail. 0 my pious friend! I have now come and expressed my distress before you.",
+              "translation": "Due to my involvement in worldly pleasures, my Master beloved Lord has become angry with me. Now when I try to bring him around, I fail. O my pious friend! I have now come and expressed my distress before you.",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/665.json
+++ b/data/Kabit Savaiye/665.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "O my co-congregational friends! When will the beloved Lord make me drink the loving elixir of spiritual union and satiate me; and when will the effulgent and kind Lord become benevolent and appease the desire of my mind?  (665)",
+              "translation": "O my co-congregational friends! When will the beloved Lord make me drink the loving elixir of spiritual union and satiate me; and when will the effulgent and kind Lord become benevolent and appease the desire of my mind? (665)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/666.json
+++ b/data/Kabit Savaiye/666.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Just as consuming some intoxicating substance, all awareness and consciousness is lost, (a man becomes unconscious), now drinking it in the form of Naam Amrit, it has become a means of inner consciousness.  (666)",
+              "translation": "Just as consuming some intoxicating substance, all awareness and consciousness is lost, (a man becomes unconscious), now drinking it in the form of Naam Amrit, it has become a means of inner consciousness. (666)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/667.json
+++ b/data/Kabit Savaiye/667.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Why has my heart not burst, receiving the message that my dear beloved will stay away from me in other place? What all blunders made may I count and recall, I have no answer of it.  (667)",
+              "translation": "Why has my heart not burst, receiving the message that my dear beloved will stay away from me in other place? What all blunders made may I count and recall, I have no answer of it. (667)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/670.json
+++ b/data/Kabit Savaiye/670.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Previously in my spiritual tranquility, I had the happiness and bliss of being near Him, but I am now crying with pangs of separation.  (670)",
+              "translation": "Previously in my spiritual tranquility, I had the happiness and bliss of being near Him, but I am now crying with pangs of separation. (670)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/671.json
+++ b/data/Kabit Savaiye/671.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "(So by such type of worship) ignorant and blind of knowledge consider Lord's worship being performed, but instead, they are slandering Him. Remaining silent is far better than this type of worship.  (671)",
+              "translation": "(So by such type of worship) ignorant and blind of knowledge consider Lord's worship being performed, but instead, they are slandering Him. Remaining silent is far better than this type of worship. (671)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/672.json
+++ b/data/Kabit Savaiye/672.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "So that the touch of the feet of the Sikhs treading that path may keep me engrossed in the remembrance of my Lord. I may then pray before these Gursikhs to take me·-the sinner across the worldly ocean.  (672)",
+              "translation": "So that the touch of the feet of the Sikhs treading that path may keep me engrossed in the remembrance of my Lord. I may then pray before these Gursikhs to take me·-the sinner across the worldly ocean. (672)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/673.json
+++ b/data/Kabit Savaiye/673.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "The gain of pressing the feet of a tired Guru's Sikh and putting him to sleep is equal to seeing a noble and godly person a score of times.  (673)",
+              "translation": "The gain of pressing the feet of a tired Guru's Sikh and putting him to sleep is equal to seeing a noble and godly person a score of times. (673)",
               "additional_information": {}
             }
           },

--- a/data/Kabit Savaiye/674.json
+++ b/data/Kabit Savaiye/674.json
@@ -86,7 +86,7 @@
         "translations": {
           "English": {
             "Shamsher Singh Puri": {
-              "translation": "Similarly many Sikhs come into the refuge of the True Guru, and whatever devotion and love one has in the mind the , True Guru fulfils it accordingly.  (674)",
+              "translation": "Similarly many Sikhs come into the refuge of the True Guru, and whatever devotion and love one has in the mind the , True Guru fulfils it accordingly. (674)",
               "additional_information": {}
             }
           },


### PR DESCRIPTION
For correctors:
* [Database Viewer](https://database.shabados.com/sources/4/page/1/line/0)
* [Proof PDF](https://drive.google.com/file/d/1-imMygFPdXKj0DuydErsUrtg1IWiu_q7/view) ([Alternate Link](http://sikhbookclub.com/Book/Kabit-Sawaiye-Bhai-Gurdas-Ji-Steek3))
* Please use the Google Sheet to mark progress

For developers:
* Citation to use in git commits
  * `Singh, Bh. Sewa. Kabit Savaiye Bhai Gurdaas Ji Steek. 7th ed., Singh Brothers Amritsar, Dec 2011, <PAGE>, www.sikhbookclub.com/Book/Kabit-Sawaiye-Bhai-Gurdas-Ji-Steek3. Accessed 22 Jan 2019.`
  * Where `<PAGE>` can be p. 43 or pp. 43-44. Most likely all of these will be found on a single page. Use the physical page found in the photo of the PDF and not the page number of the PDF document itself.

Example git commit
```
fix(data/kabit-savaiye): update id 1IL! to match physical proof

Singh, Bh. Sewa. Kabit Savaiye Bhai Gurdaas Ji Steek. 7th ed., Singh Brothers Amritsar, Dec 2011, p. 43, www.sikhbookclub.com/Book/Kabit-Sawaiye-Bhai-Gurdas-Ji-Steek3. Accessed 22 Jan 2019.

Closes #9001
```

Sanitization:
- [x] In-place bindi `ˆ` vs stand-alone bindi `N`
  - [x] `yˆ` to `yN`
  - [x] `Yˆ` to `YN`
  - [x] `oˆ` to `oN`
  - [x] `Oˆ` to `ON`
  - [x] `Iˆ` to `IN`
  - [x] `auˆ` to `auN`
- [x] Confirm extended accents `ü`/`¨`
  - [x] `Ru` to `Rü`
  - [x] `RU` to `R¨`
  - [ ] `HU` to `§`
- [ ] Convert `wN` to `W`
- [ ] Check `~` vs `` ` `` (Adhak)
- [ ] Check `nUM` vs `nUµ`
- [ ] Check `R` vs `®`
- [ ] Check `´` vs `Ï` (Pair yayya)
- [ ] Check `N` vs `ˆ`
- [x] Check for any whitespace before vishraams
- [x] Check for apostrophes/hyphens/pair-bindi akhar in gurmukhi and act accordingly (have a discussion if unsure)
- [x] Remove any superscript numbers (i.e. ¹, ², ³, ⁴, ⁵, ...)
- [ ] Missing data from varchar(255) import, use regex search `: "(.{255})",`