### PR TITLE
build: generate only heavy vishraams in `vishraam_first_letters` column and strip line endings from `first_letters`

### DIFF
--- a/lib/build-database.js
+++ b/lib/build-database.js
@@ -10,7 +10,16 @@ const memoize = require( 'memoizee' )
 const { reduce, map, forEach } = require( 'fast.js' )
 const { unload } = require( 'freshy' )
 const { omit } = require( 'lodash' )
-const { firstLetters, toEnglish, toHindi, toShahmukhi, toUnicode } = require( 'gurmukhi-utils' )
+const {
+  firstLetters,
+  stripEndings,
+  stripVishraams,
+  stripAccentts,
+  toEnglish,
+  toHindi,
+  toShahmukhi,
+  toUnicode,
+} = require( 'gurmukhi-utils' )
 
 const colors = require( './string-colors' )
 const { findIndex } = require( './utils' )
@@ -316,17 +325,26 @@ const importLines = async trx => {
               line_id: line.id,
               source_id: sourceId,
               gurmukhi,
-              first_letters: firstLetters( gurmukhi ),
-              vishraam_first_letters: firstLetters( gurmukhi, true, true ),
+              first_letters: [
+                stripEndings,
+                stripVishraams,
+                firstLetters,
+              ].reduce( ( text, fn ) => fn( text ), gurmukhi ),
+              vishraam_first_letters: [
+                stripEndings,
+                // Retain heavy vishraams only
+                text => stripVishraams( text, { light: true, medium: true } ),
+                firstLetters,
+              ].reduce( ( text, fn ) => fn( text ), gurmukhi ),
             } )
 
-            transliterateAll( gurmukhi ).forEach( ( [ languageId, transliteration ] ) =>
+            transliterateAll( gurmukhi ).forEach( ( [ languageId, transliteration ] ) => (
               transliterationData.push( {
                 line_id: id,
                 language_id: languageId,
                 source_id: sourceId,
                 transliteration,
-              } ) )
+              } ) ) )
           } )
         } )
       ) )

--- a/lib/build-database.js
+++ b/lib/build-database.js
@@ -14,7 +14,7 @@ const {
   firstLetters,
   stripEndings,
   stripVishraams,
-  stripAccentts,
+  stripAccents,
   toEnglish,
   toHindi,
   toShahmukhi,
@@ -327,11 +327,13 @@ const importLines = async trx => {
               gurmukhi,
               first_letters: [
                 stripEndings,
+                stripAccents,
                 stripVishraams,
                 firstLetters,
               ].reduce( ( text, fn ) => fn( text ), gurmukhi ),
               vishraam_first_letters: [
                 stripEndings,
+                stripAccents,
                 // Retain heavy vishraams only
                 text => stripVishraams( text, { light: true, medium: true } ),
                 firstLetters,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3689,9 +3689,9 @@
       "dev": true
     },
     "gurmukhi-utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/gurmukhi-utils/-/gurmukhi-utils-2.3.1.tgz",
-      "integrity": "sha512-lECejg/dk8tPmA8Lo6GHP6HCWGjLsdsnRqOsh15yWLzxk6yRe5hfOtOL4bfPHdFhNRGB4NiHrslzPWPV+peixg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gurmukhi-utils/-/gurmukhi-utils-3.0.0.tgz",
+      "integrity": "sha512-IUZnry32QURJqdjNruJyB/DYJ7aycP3XZ9iOvRl2kjJfMTgiJJFQnWSa4aGgg60NmxEpgpb/k1VyTNO9Dj8EOw==",
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "commander": "^4.1.1",
     "fast.js": "^0.1.1",
     "freshy": "^1.0.4",
-    "gurmukhi-utils": "^2.3.1",
+    "gurmukhi-utils": "^3.0.0",
     "is-ascii": "^1.0.0",
     "knex": "^0.19.5",
     "lodash": "^4.17.15",


### PR DESCRIPTION
### Summary of PR
Retains only the heavy vishraams in the `vishraam_first_letters` column, to allow for #1775. Removes any line endings from first letters.

### Tests for unexpected behavior
- Build SQLite DB
- Queried for any remaining light/medium vishraams
- Queried for any unexpected line endings

### Time spent on PR
20 mins

### Linked issues
Fix #1775
I cannot find the issue for removing pauses from first letters, if there is one.

### Reviewers
@bhajneet 