### PR TITLE
fix: use correct foreign key for translation sources

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -105,7 +105,7 @@ const createSchema = knex => knex.schema
     table.increments( 'id' ).primary()
     table.string( 'name_gurmukhi' ).notNullable()
     table.string( 'name_english' ).notNullable()
-    table.integer( 'composition_id' ).references( 'id' ).inTable( 'sources' ).notNullable()
+    table.integer( 'composition_id' ).references( 'id' ).inTable( 'compositions' ).notNullable()
     table.integer( 'language_id' ).references( 'id' ).inTable( 'languages' ).notNullable()
   } )
   .createTable( 'translations', table => {


### PR DESCRIPTION
### Summary of PR
The composition id in the translation_sources table references the id in the sources table instead of the compositions table.

### Reviewers
@Harjot1Singh @bhajneet  @Sarabveer 