### PR TITLE
Check and Correct Author IDs of 22 Vaars in SGGS Ji

### DIFF
--- a/data/Sri Guru Granth Sahib Ji/0141.json
+++ b/data/Sri Guru Granth Sahib Ji/0141.json
@@ -1334,7 +1334,7 @@
   {
     "id": "51X",
     "sttm_id": 384,
-    "writer": "Guru Nanak Dev Ji",
+    "writer": "Guru Ramdas Ji",
     "section": "Raag Maajh",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0317.json
+++ b/data/Sri Guru Granth Sahib Ji/0317.json
@@ -308,7 +308,7 @@
   {
     "id": "L5E",
     "sttm_id": 1218,
-    "writer": "Guru Arjan Dev Ji",
+    "writer": "Guru Ramdas Ji",
     "section": "Raag Gauree",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0463.json
+++ b/data/Sri Guru Granth Sahib Ji/0463.json
@@ -1823,7 +1823,7 @@
   {
     "id": "ASY",
     "sttm_id": 1691,
-    "writer": "Guru Nanak Dev Ji",
+    "writer": "Guru Angad Dev Ji",
     "section": "Raag Aasaa",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0551.json
+++ b/data/Sri Guru Granth Sahib Ji/0551.json
@@ -251,7 +251,7 @@
   {
     "id": "N2Z",
     "sttm_id": 2100,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Ramdas Ji",
     "section": "Raag Bihaagraa",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0556.json
+++ b/data/Sri Guru Granth Sahib Ji/0556.json
@@ -1343,7 +1343,7 @@
   {
     "id": "810",
     "sttm_id": 2141,
-    "writer": "Guru Ramdas Ji",
+    "writer": "Guru Amardas Ji",
     "section": "Raag Bihaagraa",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0590.json
+++ b/data/Sri Guru Granth Sahib Ji/0590.json
@@ -2,7 +2,7 @@
   {
     "id": "5KR",
     "sttm_id": 2232,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Vadhans",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0594.json
+++ b/data/Sri Guru Granth Sahib Ji/0594.json
@@ -299,7 +299,7 @@
   {
     "id": "TV2",
     "sttm_id": 2261,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Vadhans",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0594.json
+++ b/data/Sri Guru Granth Sahib Ji/0594.json
@@ -452,7 +452,7 @@
   {
     "id": "GU7",
     "sttm_id": 2262,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Vadhans",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/0853.json
+++ b/data/Sri Guru Granth Sahib Ji/0853.json
@@ -2,7 +2,7 @@
   {
     "id": "Z76",
     "sttm_id": 3189,
-    "writer": "Guru Ramdas Ji",
+    "writer": "Guru Amardas Ji",
     "section": "Raag Bilaaval",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1251.json
+++ b/data/Sri Guru Granth Sahib Ji/1251.json
@@ -1391,7 +1391,7 @@
   {
     "id": "DM7",
     "sttm_id": 4525,
-    "writer": "Guru Arjan Dev Ji",
+    "writer": "Guru Ramdas Ji",
     "section": "Raag Saarang",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1279.json
+++ b/data/Sri Guru Granth Sahib Ji/1279.json
@@ -1745,7 +1745,7 @@
   {
     "id": "Y0N",
     "sttm_id": 4611,
-    "writer": "Guru Angad Dev Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1280.json
+++ b/data/Sri Guru Granth Sahib Ji/1280.json
@@ -1994,7 +1994,7 @@
   {
     "id": "5JW",
     "sttm_id": 4620,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1280.json
+++ b/data/Sri Guru Granth Sahib Ji/1280.json
@@ -308,7 +308,7 @@
   {
     "id": "S2M",
     "sttm_id": 4614,
-    "writer": "Guru Angad Dev Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1280.json
+++ b/data/Sri Guru Granth Sahib Ji/1280.json
@@ -1151,7 +1151,7 @@
   {
     "id": "GLY",
     "sttm_id": 4617,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1281.json
+++ b/data/Sri Guru Granth Sahib Ji/1281.json
@@ -644,7 +644,7 @@
   {
     "id": "SVW",
     "sttm_id": 4623,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1282.json
+++ b/data/Sri Guru Granth Sahib Ji/1282.json
@@ -2,7 +2,7 @@
   {
     "id": "LE5",
     "sttm_id": 4626,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1282.json
+++ b/data/Sri Guru Granth Sahib Ji/1282.json
@@ -893,7 +893,7 @@
   {
     "id": "HQE",
     "sttm_id": 4629,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [
@@ -1880,7 +1880,7 @@
   {
     "id": "HMR",
     "sttm_id": 4632,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1283.json
+++ b/data/Sri Guru Granth Sahib Ji/1283.json
@@ -548,7 +548,7 @@
   {
     "id": "DR3",
     "sttm_id": 4635,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [
@@ -1487,7 +1487,7 @@
   {
     "id": "11M",
     "sttm_id": 4638,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1284.json
+++ b/data/Sri Guru Granth Sahib Ji/1284.json
@@ -251,7 +251,7 @@
   {
     "id": "RQX",
     "sttm_id": 4641,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [
@@ -998,7 +998,7 @@
   {
     "id": "3WJ",
     "sttm_id": 4644,
-    "writer": "Guru Arjan Dev Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [
@@ -1937,7 +1937,7 @@
   {
     "id": "J7W",
     "sttm_id": 4647,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1285.json
+++ b/data/Sri Guru Granth Sahib Ji/1285.json
@@ -452,7 +452,7 @@
   {
     "id": "D2N",
     "sttm_id": 4650,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [
@@ -1199,7 +1199,7 @@
   {
     "id": "BS9",
     "sttm_id": 4653,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [

--- a/data/Sri Guru Granth Sahib Ji/1286.json
+++ b/data/Sri Guru Granth Sahib Ji/1286.json
@@ -2,7 +2,7 @@
   {
     "id": "HDX",
     "sttm_id": 4656,
-    "writer": "Guru Amardas Ji",
+    "writer": "Guru Nanak Dev Ji",
     "section": "Raag Malaar",
     "subsection": null,
     "lines": [


### PR DESCRIPTION
Taken from #1756
	  
> In Sri Guru Granth Sahib Ji, there are 22 Vaars. The focus if this PR is to check the authors of the Shabads (Saloks and Pauris) in the Vaars.
>
> Vaars are traditionally composed with Pauris, this can be seen in Basant Ki Vaar and Vaar of Satta Doom and Balwand.
>
> Guru Arjan Dev Ji attached Saloks to the 20 Vaars. The author of the Pauris in the Vaar is the Mehla given in the beginning of the Vaar and the author of the Salok is the Mehla given in the Salok Sirlekh.
>
> For example, in Assa Ki Vaar, all the Pauris are written by Guru Nanak Dev Ji, but the Saloks are either written by Guru Nanak Dev Ji or Guru Angad Dev Ji.
>
> Additional Saloks not used in Vaars were put in Salok Varan te Vadheek (lit. Extra Saloks not in Vaars).