### PR TITLE
data: standardise asset collection

### DIFF
--- a/collections/assets/akkb.json
+++ b/collections/assets/akkb.json
@@ -1,8 +1,12 @@
 {
   "name": {
-    "Latn": "Amrit Kirtan"
+    "Latn": "Amrit Kirtan",
+    "Guru": "ਅੰਮ੍ਰਿਤ ਕੀਰਤਨ"
   },
-  "meta": {
-    "publisher": "Khalsa Brothers"
+  "source": {
+    "title": "Amrit Kirtan",
+    "publisher": {
+      "name": "Khalsa Brothers"
+    }
   }
 }

--- a/collections/assets/dgdg.json
+++ b/collections/assets/dgdg.json
@@ -1,8 +1,16 @@
 {
   "name": {
-    "Latn": "Das Granthi"
+    "Latn": "Das Granthi",
+    "Guru": "ਦਸ ਗ੍ਰੰਥੀ"
   },
-  "citation": {
-    "mla": "Das Granthi. SGPC, Sri Amritsar, Jul 2014."
+  "source": {
+    "title": "Das Granthi",
+    "publisher": {
+      "name": "SGPC",
+      "city": "Sri Amritsar"
+    },
+    "publication": {
+      "date": "2014-07"
+    }
   }
 }

--- a/collections/assets/dsko.json
+++ b/collections/assets/dsko.json
@@ -1,13 +1,22 @@
 {
   "name": {
-    "Latn": "Sri Dasam Granth Sahib Translation"
+    "Latn": "Sri Dasam Granth Sahib Translation",
+    "Guru": "ਸ੍ਰੀ ਦਸਮ ਗ੍ਰੰਥ ਸਾਹਿਬ ਅਨੁਵਾਦ"
   },
-  "meta": {
-    "author": {
-      "first": "Dr. Surinder S",
-      "last": "Kohli"
+  "source": {
+    "authors": [
+      {
+        "prefix": "Dr.",
+        "first": "Surinder S",
+        "last": "Kohli"
+      }
+    ],
+    "title": "Sri Dasam Granth Sahib Translation",
+    "publisher": {
+      "name": "Sikh National Heritage Trust"
     },
-    "publisher": "Sikh National Heritage Trust",
-    "publication_date": "1 Jan 2003"
+    "publication": {
+      "date": "2003-01-01"
+    }
   }
 }

--- a/collections/assets/dssk.json
+++ b/collections/assets/dssk.json
@@ -1,13 +1,19 @@
 {
   "name": {
-    "Latn": "Siri Guru Granth Sahib Ji"
+    "Latn": "Siri Guru Granth Sahib Ji",
+    "Guru": "ਸਿਰੀ ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ ਜੀ"
   },
-  "meta": {
-    "author": {
-      "first": "Dr. Sant S",
-      "last": "Khalsa"
-    },
+  "source": {
+    "authors": [
+      {
+        "prefix": "Dr.",
+        "first": "Sant S",
+        "last": "Khalsa"
+      }
+    ],
     "title": "Siri Guru Granth Sahib Ji",
-    "publication_date": "Mar 2013"
+    "publication": {
+      "date": "2013-03"
+    }
   }
 }

--- a/collections/assets/gsnl.json
+++ b/collections/assets/gsnl.json
@@ -1,8 +1,25 @@
 {
   "name": {
-    "Latn": "Bhai Nand Lal Granthavali"
+    "Latn": "Bhai Nand Lal Granthavali",
+    "Guru": "ਭਾਈ ਨੰਦ ਲਾਲ ਗ੍ਰੰਥਾਵਲੀ"
   },
-  "citation": {
-    "mla": "Singh, Ganda. Bhai Nand Lal Granthavali. 4th ed., Punjabi University, Patiala, 2009, www.archive.org/details/BhaiNandLalGranthavali. Accessed 22 Jan 2019."
+  "source": {
+    "authors": [
+      {
+        "first": "Ganda",
+        "last": "Singh"
+      }
+    ],
+    "title": "Bhai Nand Lal Granthavali",
+    "publisher": {
+      "name": "Punjabi University",
+      "city": "Patiala"
+    },
+    "publication": {
+      "date": "2009",
+      "version": "4th ed."
+    },
+    "url": "www.archive.org/details/BhaiNandLalGranthavali",
+    "accessed": "2019-01-22"
   }
 }

--- a/collections/assets/jsds.json
+++ b/collections/assets/jsds.json
@@ -1,12 +1,24 @@
 {
   "name": {
-    "Latn": "Sri Guru Granth Sahib Ji Shudh Ucharan"
+    "Latn": "Sri Guru Granth Sahib Ji Shudh Ucharan",
+    "Guru": "ਸ੍ਰੀ ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ ਜੀ ਸ਼ੁੱਧ ਉਚਾਰਨ"
   },
-  "meta": {
-    "publisher_city": "Sri Damdami Taksaal",
-    "publication_date": "Oct 2015"
-  },
-  "citation": {
-    "mla": "Dauder, Jaswant S. Sri Guru Granth Sahib Ji Shudh Ucharan, Arth Paath Vishraam Pothi, Sri Damdami Taksaal. Oct 2015, www.gursevak.com/drupal7/sites/default/files/Vishram%20Sri%20Guru%20Granth%20Sahib%20Jee.pdf. Accessed 18 May 2020."
+  "source": {
+    "authors": [
+      {
+        "first": "Jaswant S",
+        "last": "Dauder"
+      }
+    ],
+    "title": "Sri Guru Granth Sahib Ji Shudh Ucharan",
+    "subtitle": "Arth Paath Vishraam Pothi",
+    "publisher": {
+      "name": "Sri Damdami Taksaal"
+    },
+    "publication": {
+      "date": "2015-10"
+    },
+    "url": "www.gursevak.com/drupal7/sites/default/files/Vishram%20Sri%20Guru%20Granth%20Sahib%20Jee.pdf",
+    "accessed": "2020-05-18"
   }
 }

--- a/collections/assets/jsts.json
+++ b/collections/assets/jsts.json
@@ -3,18 +3,21 @@
     "Latn": "Nitnem Saral Steek",
     "Guru": "ਨਿਤਨੇਮ ਸਰਲ ਸਟੀਕ"
   },
-  "meta": {
-    "author": {
-      "first": "Joginder S",
-      "last": "Talwara"
-    },
+  "source": {
+    "authors": [
+      {
+        "first": "Joginder S",
+        "last": "Talwara"
+      }
+    ],
     "title": "Nitnem Saral Steek",
-    "version": "6th ed.",
-    "publisher": "Singh Brothers",
-    "publisher_city": "Amritsar",
-    "publication_date": "Jan 2011"
-  },
-  "citation": {
-    "mla": "Talwara, Joginder S. Nitnem Saral Steek. 6th ed., Singh Brothers, Amritsar, Jan 2011."
+    "publisher": {
+      "name": "Singh Brothers",
+      "city": "Amritsar"
+    },
+    "publication": {
+      "date": "2011-01",
+      "version": "6th ed."
+    }
   }
 }

--- a/collections/assets/jvbg.json
+++ b/collections/assets/jvbg.json
@@ -1,8 +1,29 @@
 {
   "name": {
-    "Latn": "Vārān Bhāī Gurdās (Text, Transliteration, and Translation)"
+    "Latn": "Vārān Bhāī Gurdās (Text, Transliteration, and Translation)",
+    "Guru": "ਵਾਰਾਂ ਭਾਈ ਗੁਰਦਾਸ (ਮੂਲ, ਲਿਪੀਅੰਤਰ, ਅਤੇ ਅਨੁਵਾਦ)"
   },
-  "citation": {
-    "mla": "Singh, Jodh. Vārān Bhāī Gurdās (Text, Transliteration, and Translation). Vol. 1-2, 2nd ed., B. Chattar Singh Jiwan Singh, Amritsar, 2013, www.archive.org/details/VaraanBhaiGurdasTextTransliterationAndTranslation-Vol1. Accessed 18 May 2020."
+  "source": {
+    "authors": [
+      {
+        "first": "Jodh",
+        "last": "Singh"
+      }
+    ],
+    "title": "Vārān Bhāī Gurdās",
+    "subtitle": "Text, Transliteration, and Translation",
+    "publisher": {
+      "name": "B. Chattar Singh Jiwan Singh",
+      "city": "Amritsar"
+    },
+    "publication": {
+      "date": "2013",
+      "version": "2nd ed."
+    },
+    "volume": {
+      "total": 2
+    },
+    "url": "www.archive.org/details/VaraanBhaiGurdasTextTransliterationAndTranslation-Vol1",
+    "accessed": "2020-05-18"
   }
 }

--- a/collections/assets/kegp.json
+++ b/collections/assets/kegp.json
@@ -2,7 +2,21 @@
   "name": {
     "Latn": "Kalaam-e-Goya"
   },
-  "citation": {
-    "mla": "Kalaam-e-Goya. Translated by Pritpal S Bindra, Institute of Sikh Studies, Chandigarh, 2003"
+  "source": {
+    "authors": [
+      {
+        "first": "Pritpal S",
+        "last": "Bindra",
+        "role": "Translator"
+      }
+    ],
+    "title": "Kalaam-e-Goya",
+    "publisher": {
+      "name": "Institute of Sikh Studies",
+      "city": "Chandigarh"
+    },
+    "publication": {
+      "date": "2003"
+    }
   }
 }

--- a/collections/assets/nkft.json
+++ b/collections/assets/nkft.json
@@ -1,8 +1,20 @@
 {
   "name": {
-    "Latn": "Faridkot Wala Teeka"
+    "Latn": "Faridkot Wala Teeka",
+    "Guru": "ਫਰੀਦਕੋਟ ਵਾਲਾ ਟੀਕਾ"
   },
-  "citation": {
-    "mla": "Singh, Badan. Fridkot Wala Teeka. Bh. Baljinder Singh Rara Sahib, www.ik13.com/PDFS/Fridkot_Wala_Teeka.pdf. Accessed 24 May 2020."
+  "source": {
+    "authors": [
+      {
+        "first": "Badan",
+        "last": "Singh"
+      }
+    ],
+    "title": "Fridkot Wala Teeka",
+    "publisher": {
+      "name": "Bh. Baljinder Singh Rara Sahib"
+    },
+    "url": "www.ik13.com/PDFS/Fridkot_Wala_Teeka.pdf",
+    "accessed": "2020-05-24"
   }
 }

--- a/collections/assets/nthb.json
+++ b/collections/assets/nthb.json
@@ -1,5 +1,6 @@
 {
   "name": {
-    "Latn": "Nitnem Te Hor Baniaa(n)"
+    "Latn": "Nitnem Te Hor Baniaa(n)",
+    "Guru": "ਨਿਤਨੇਮ ਤੇ ਹੋਰ ਬਾਣੀਆਂ"
   }
 }

--- a/collections/assets/psst.json
+++ b/collections/assets/psst.json
@@ -1,8 +1,28 @@
 {
   "name": {
-    "Latn": "Prof Sahib Singh"
+    "Latn": "Prof Sahib Singh",
+    "Guru": "ਪ੍ਰੋ. ਸਾਹਿਬ ਸਿੰਘ"
   },
-  "citation": {
-    "mla": "Singh, Sahib. Sri Guru Granth Darpan. Vol. 1-10, Raaj Publishers, Hoshiarpur/Jalandhar, 1972, www.archive.org/details/SriGuruGranthSahibDarpan-Volume1. Accessed 18 May 2020."
+  "source": {
+    "authors": [
+      {
+        "prefix": "Prof",
+        "first": "Sahib",
+        "last": "Singh"
+      }
+    ],
+    "title": "Sri Guru Granth Darpan",
+    "publisher": {
+      "name": "Raaj Publishers",
+      "city": "Hoshiarpur/Jalandhar"
+    },
+    "publication": {
+      "date": "1972"
+    },
+    "volume": {
+      "total": 10
+    },
+    "url": "www.archive.org/details/SriGuruGranthSahibDarpan-Volume1",
+    "accessed": "2020-05-18"
   }
 }

--- a/collections/assets/rsjd.json
+++ b/collections/assets/rsjd.json
@@ -1,14 +1,25 @@
 {
   "name": {
-    "Latn": "Sri Dasam Granth"
+    "Latn": "Sri Dasam Granth",
+    "Guru": "ਸ੍ਰੀ ਦਸਮ ਗ੍ਰੰਥ"
   },
-  "meta": {
-    "author": {
-      "first": "Ratan S",
-      "last": "Jaggi"
-    }
-  },
-  "citation": {
-    "mla": "Jaggi, Ratan S. Sri Dasam Granth. Gobind Sadan, New Delhi, www.gobindsadan.org/download/148/siri-dasam-granth/1363/dasam-granth-complete.pdf. Created 15 Sep 2007. Uploaded 02 Nov 2017. Accessed 22 Jan 2019."
+  "source": {
+    "authors": [
+      {
+        "first": "Ratan S",
+        "last": "Jaggi"
+      }
+    ],
+    "title": "Sri Dasam Granth",
+    "publisher": {
+      "name": "Gobind Sadan",
+      "city": "New Delhi"
+    },
+    "publication": {
+      "date": "2007-09-15"
+    },
+    "url": "www.gobindsadan.org/download/148/siri-dasam-granth/1363/dasam-granth-complete.pdf",
+    "accessed": "2019-01-22",
+    "notes": "Uploaded 2017-11-02"
   }
 }

--- a/collections/assets/sbms.json
+++ b/collections/assets/sbms.json
@@ -2,13 +2,27 @@
   "name": {
     "Latn": "Sri Guru Granth Sahib (English & Punjabi Translation)"
   },
-  "meta": {
-    "author": {
-      "first": "Manmohan",
-      "last": "Singh"
-    }
-  },
-  "citation": {
-    "mla": "Singh, Manmohan. Sri Guru Granth Sahib (English & Punjabi Translation). Vol 1-8, 6th & 8th ed., SGPC, Amritsar, 2006-2009. www.archive.org/details/SriGuruGranthSahibEnglishAndPunjabiTranslation-Vol.1. Accessed 24 May 2020."
+  "source": {
+    "authors": [
+      {
+        "first": "Manmohan",
+        "last": "Singh"
+      }
+    ],
+    "title": "Sri Guru Granth Sahib",
+    "subtitle": "English & Punjabi Translation",
+    "publisher": {
+      "name": "SGPC",
+      "city": "Amritsar"
+    },
+    "publication": {
+      "date": "2006-2009",
+      "version": "6th & 8th ed."
+    },
+    "volume": {
+      "total": 8
+    },
+    "url": "www.archive.org/details/SriGuruGranthSahibEnglishAndPunjabiTranslation-Vol.1",
+    "accessed": "2020-05-24"
   }
 }

--- a/collections/assets/snst.json
+++ b/collections/assets/snst.json
@@ -1,5 +1,17 @@
 {
   "name": {
     "Latn": "SikhNet Spanish Translation"
+  },
+  "source": {
+    "authors": [
+      {
+        "first": "SikhNet",
+        "last": "Team"
+      }
+    ],
+    "title": "SikhNet Spanish Translation",
+    "publisher": {
+      "name": "SikhNet"
+    }
   }
 }

--- a/collections/assets/sotk.json
+++ b/collections/assets/sotk.json
@@ -2,20 +2,22 @@
   "name": {
     "Latn": "Sikhs of the Khalsa"
   },
-  "meta": {
-    "author": {
-      "first": "W. H.",
-      "last": "McLeod"
-    },
+  "source": {
+    "authors": [
+      {
+        "first": "W. H.",
+        "last": "McLeod"
+      }
+    ],
     "title": "Sikhs of the Khalsa",
     "subtitle": "A History of the Khalsa Rahit",
-    "publisher": "Oxford University Press",
-    "publication_date": "2003",
+    "publisher": {
+      "name": "Oxford University Press",
+      "country": "India"
+    },
+    "publication": {
+      "date": "2003"
+    },
     "url": "https://books.google.com/books?id=HIrXAAAAMAAJ"
-  },
-  "citation": {
-    "apa": "McLeod, W. H. (2003). Sikhs of the Khalsa: A History of the Khalsa Rahit. India: Oxford University Press.",
-    "mla": "McLeod, W. H. Sikhs of the Khalsa: A History of the Khalsa Rahit. India, Oxford University Press, 2003.",
-    "chicago": "McLeod, W. H. Sikhs of the Khalsa: A History of the Khalsa Rahit. India: Oxford University Press, 2003."
   }
 }

--- a/collections/assets/srme.json
+++ b/collections/assets/srme.json
@@ -2,7 +2,22 @@
   "name": {
     "Latn": "Sikh Rehat Maryada (English)"
   },
-  "citation": {
-    "mla": "Rehat Maryada. SGPC, 30 May 2013, https://old.sgpc.net/CDN/Sikh_Rehat_Maryada_English.pdf. Accessed 13 Nov 2023."
+  "source": {
+    "authors": [
+      {
+        "first": "SGPC",
+        "last": "Committee"
+      }
+    ],
+    "title": "Sikh Rehat Maryada",
+    "subtitle": "English Translation",
+    "publisher": {
+      "name": "SGPC"
+    },
+    "publication": {
+      "date": "2013-05-30"
+    },
+    "url": "https://old.sgpc.net/CDN/Sikh_Rehat_Maryada_English.pdf",
+    "accessed": "2023-11-13"
   }
 }

--- a/collections/assets/ssa2.json
+++ b/collections/assets/ssa2.json
@@ -1,12 +1,27 @@
 {
   "name": {
-    "Latn": "Shabadaarth"
+    "Latn": "Shabadaarth",
+    "Guru": "ਸ਼ਬਦਾਰਥ"
   },
-  "meta": {
-    "publisher_city": "Sri Amritsar",
-    "publication_date": "2009-2012"
-  },
-  "citation": {
-    "mla": "Shabadaarth. Vol. 1-4, SGPC, Sri Amritsar, 2009-2012, www.archive.org/details/ShabdaarthSriGuruGranthSahibJi-Part1. Accessed 22 Jan 2019."
+  "source": {
+    "authors": [
+      {
+        "first": "SGPC",
+        "last": "Committee"
+      }
+    ],
+    "title": "Shabadaarth",
+    "publisher": {
+      "name": "SGPC",
+      "city": "Sri Amritsar"
+    },
+    "publication": {
+      "date": "2009-2012"
+    },
+    "volume": {
+      "total": 4
+    },
+    "url": "www.archive.org/details/ShabdaarthSriGuruGranthSahibJi-Part1",
+    "accessed": "2019-01-22"
   }
 }

--- a/collections/assets/ssks.json
+++ b/collections/assets/ssks.json
@@ -1,8 +1,25 @@
 {
   "name": {
-    "Latn": "Kabit Sawaiye Bhai Gurdas Ji Steek"
+    "Latn": "Kabit Sawaiye Bhai Gurdas Ji Steek",
+    "Guru": "ਕਬਿਤ ਸਵੱਯੇ ਭਾਈ ਗੁਰਦਾਸ ਜੀ ਸਟੀਕ"
   },
-  "citation": {
-    "mla": "Singh, Sewa. Kabit Sawaiye Bhai Gurdas Ji Steek. 7th ed., Singh Brothers, Amritsar, Dec 2011, www.archive.org/details/KabitSavaiyeBhaiGurdasJiSteek. Accessed 22 Jan 2019."
+  "source": {
+    "authors": [
+      {
+        "first": "Sewa",
+        "last": "Singh"
+      }
+    ],
+    "title": "Kabit Sawaiye Bhai Gurdas Ji Steek",
+    "publisher": {
+      "name": "Singh Brothers",
+      "city": "Amritsar"
+    },
+    "publication": {
+      "date": "2011-12",
+      "version": "7th ed."
+    },
+    "url": "www.archive.org/details/KabitSavaiyeBhaiGurdasJiSteek",
+    "accessed": "2019-01-22"
   }
 }

--- a/collections/assets/sspk.json
+++ b/collections/assets/sspk.json
@@ -1,16 +1,23 @@
 {
   "name": {
-    "Latn": "Kabitt Swayye Bhai Gurdas Ji"
+    "Latn": "Kabitt Swayye Bhai Gurdas Ji",
+    "Guru": "ਕਬਿਤ ਸਵੱਯੇ ਭਾਈ ਗੁਰਦਾਸ ਜੀ"
   },
-  "meta": {
-    "author": {
-      "first": "Shamsher S",
-      "last": "Puri"
-    },
+  "source": {
+    "authors": [
+      {
+        "first": "Shamsher S",
+        "last": "Puri"
+      }
+    ],
     "title": "Kabitt Swayye Bhai Gurdas Ji",
-    "version": "1st ed.",
-    "publisher": "Singh Brothers",
-    "publisher_city": "Amritsar",
-    "publication_date": "May 2007"
+    "publisher": {
+      "name": "Singh Brothers",
+      "city": "Amritsar"
+    },
+    "publication": {
+      "date": "2007-05",
+      "version": "1st ed."
+    }
   }
 }

--- a/collections/assets/sssk.json
+++ b/collections/assets/sssk.json
@@ -1,13 +1,18 @@
 {
   "name": {
-    "Latn": "Kabit Sawayan Bhai Gurdas Ji Steek"
+    "Latn": "Kabit Sawayan Bhai Gurdas Ji Steek",
+    "Guru": "ਕਬਿਤ ਸਵੱਯਾਂ ਭਾਈ ਗੁਰਦਾਸ ਜੀ ਸਟੀਕ"
   },
-  "meta": {
-    "author": {
-      "first": "Sampuran",
-      "last": "Singh"
-    },
+  "source": {
+    "authors": [
+      {
+        "first": "Sampuran",
+        "last": "Singh"
+      }
+    ],
     "title": "Kabit Sawayan Bhai Gurdas Ji Steek",
-    "publication_date": "2012"
+    "publication": {
+      "date": "2012"
+    }
   }
 }

--- a/collections/assets/vbgs.json
+++ b/collections/assets/vbgs.json
@@ -1,14 +1,25 @@
 {
   "name": {
-    "Latn": "Varan Bhai Gurdas Steek"
+    "Latn": "Varan Bhai Gurdas Steek",
+    "Guru": "ਵਾਰਾਂ ਭਾਈ ਗੁਰਦਾਸ ਸਟੀਕ"
   },
-  "meta": {
-    "author": {
-      "first": "Vir",
-      "last": "Singh"
-    }
-  },
-  "citation": {
-    "mla": "Singh, Vir. Varan Bhai Gurdas Steek. 22nd ed., New Delhi, Jul 2012, www.archive.org/details/VaraanBhaiGurdasSteek-BhaiVirSingh. Accessed 18 May 2020."
+  "source": {
+    "authors": [
+      {
+        "prefix": "Bhai",
+        "first": "Vir",
+        "last": "Singh"
+      }
+    ],
+    "title": "Varan Bhai Gurdas Steek",
+    "publisher": {
+      "city": "New Delhi"
+    },
+    "publication": {
+      "date": "2012-07",
+      "version": "22nd ed."
+    },
+    "url": "www.archive.org/details/VaraanBhaiGurdasSteek-BhaiVirSingh",
+    "accessed": "2020-05-18"
   }
 }

--- a/collections/assets/vgrg.json
+++ b/collections/assets/vgrg.json
@@ -1,8 +1,28 @@
 {
   "name": {
-    "Latn": "Varan Giaan Ratnaavli Bhai Gurdaas Ji"
+    "Latn": "Varan Giaan Ratnaavli Bhai Gurdaas Ji",
+    "Guru": "ਵਾਰਾਂ ਗਿਆਨ ਰਤਨਾਵਲੀ ਭਾਈ ਗੁਰਦਾਸ ਜੀ"
   },
-  "citation": {
-    "mla": "Ashok, Shamsher S, and Chakar, Amar S. Varan Giaan Ratnaavli Bhai Gurdaas Ji. SGPC, Sri Amritsar, Nov 2011, www.vidhia.com/Bhai%20Gurdaas%20Ji/Vaaran%20Bhai%20Gurdaas%20Ji%20-%20SGPC.pdf. Accessed 22 Jan 2019."
+  "source": {
+    "authors": [
+      {
+        "first": "Shamsher S",
+        "last": "Ashok"
+      },
+      {
+        "first": "Amar S",
+        "last": "Chakar"
+      }
+    ],
+    "title": "Varan Giaan Ratnaavli Bhai Gurdaas Ji",
+    "publisher": {
+      "name": "SGPC",
+      "city": "Sri Amritsar"
+    },
+    "publication": {
+      "date": "2011-11"
+    },
+    "url": "www.vidhia.com/Bhai%20Gurdaas%20Ji/Vaaran%20Bhai%20Gurdaas%20Ji%20-%20SGPC.pdf",
+    "accessed": "2019-01-22"
   }
 }


### PR DESCRIPTION
## Summary

Standardise the asset collection according to the JSON schema.

Mainly, standardises the citation fields so that they can be generated.

Some additional detail has been added in.

## Challenges

- Currently, the `name` field is defined as an ISO-15924 field. This specifies all keys as mandatory. Is this an incorrect assumption? Or can the names be internationalized?

- Some of the data is unavaliable for the source - see CI for what's missing out of the mandatory fields. We can discuss what makes sense.