### PR TITLE
feat: add Giaan Khand search-first web and API stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ data.tmp/
 
 # Generated types
 .types/
+
+# Local product runtime
+.tmp/
+.next/

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1,0 +1,950 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Giaan Khand Public API",
+    "version": "0.1.0"
+  },
+  "components": {
+    "schemas": {
+      "WorkSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "title": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "translation": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "summary": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "classification": {
+            "type": "string"
+          },
+          "textShape": {
+            "type": "string"
+          },
+          "featured": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "title",
+          "translation",
+          "classification",
+          "textShape"
+        ]
+      },
+      "WorksResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "translation": {
+                  "type": "object",
+                  "nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "summary": {
+                  "type": "object",
+                  "nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "classification": {
+                  "type": "string"
+                },
+                "textShape": {
+                  "type": "string"
+                },
+                "featured": {
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "required": [
+                "id",
+                "slug",
+                "title",
+                "translation",
+                "classification",
+                "textShape"
+              ]
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "StructureNodeSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "nodeType": {
+            "type": "string"
+          },
+          "title": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "translation": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "position": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "slug",
+          "nodeType",
+          "title",
+          "translation",
+          "description",
+          "position"
+        ]
+      },
+      "WorkDetailResponse": {
+        "type": "object",
+        "properties": {
+          "work": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "title": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "translation": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "summary": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "classification": {
+                "type": "string"
+              },
+              "textShape": {
+                "type": "string"
+              },
+              "featured": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "required": [
+              "id",
+              "slug",
+              "title",
+              "translation",
+              "classification",
+              "textShape"
+            ]
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "nodeType": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "translation": {
+                  "type": "object",
+                  "nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "description": {
+                  "type": "object",
+                  "nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "position": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id",
+                "slug",
+                "nodeType",
+                "title",
+                "translation",
+                "description",
+                "position"
+              ]
+            }
+          }
+        },
+        "required": [
+          "work",
+          "sections"
+        ]
+      },
+      "PassageDetailResponse": {
+        "type": "object",
+        "properties": {
+          "passageId": {
+            "type": "string"
+          },
+          "workSlug": {
+            "type": "string"
+          },
+          "workTitle": {
+            "type": "string"
+          },
+          "structureLabel": {
+            "type": "string"
+          },
+          "locatorLabel": {
+            "type": "string"
+          },
+          "originalText": {
+            "type": "string"
+          },
+          "pageStart": {
+            "type": "integer",
+            "nullable": true
+          },
+          "pageEnd": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "passageId",
+          "workSlug",
+          "workTitle",
+          "structureLabel",
+          "locatorLabel",
+          "originalText",
+          "pageStart",
+          "pageEnd"
+        ]
+      },
+      "PangtiSearchItem": {
+        "type": "object",
+        "properties": {
+          "passageId": {
+            "type": "string"
+          },
+          "workSlug": {
+            "type": "string"
+          },
+          "workTitle": {
+            "type": "string"
+          },
+          "structureLabel": {
+            "type": "string"
+          },
+          "locatorLabel": {
+            "type": "string"
+          },
+          "originalText": {
+            "type": "string"
+          },
+          "matchedBy": {
+            "type": "string",
+            "enum": [
+              "gurmukhi",
+              "latin-initials"
+            ]
+          },
+          "matchedInitials": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "passageId",
+          "workSlug",
+          "workTitle",
+          "structureLabel",
+          "locatorLabel",
+          "originalText",
+          "matchedBy",
+          "matchedInitials",
+          "score"
+        ]
+      },
+      "PangtiSearchResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "passageId": {
+                  "type": "string"
+                },
+                "workSlug": {
+                  "type": "string"
+                },
+                "workTitle": {
+                  "type": "string"
+                },
+                "structureLabel": {
+                  "type": "string"
+                },
+                "locatorLabel": {
+                  "type": "string"
+                },
+                "originalText": {
+                  "type": "string"
+                },
+                "matchedBy": {
+                  "type": "string",
+                  "enum": [
+                    "gurmukhi",
+                    "latin-initials"
+                  ]
+                },
+                "matchedInitials": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "passageId",
+                "workSlug",
+                "workTitle",
+                "structureLabel",
+                "locatorLabel",
+                "originalText",
+                "matchedBy",
+                "matchedInitials",
+                "score"
+              ]
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "nullable": true
+          },
+          "queryMeta": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "gurmukhi",
+                  "latin-initials"
+                ]
+              },
+              "normalizedQuery": {
+                "type": "string"
+              },
+              "page": {
+                "type": "integer",
+                "minimum": 0,
+                "exclusiveMinimum": true
+              },
+              "limit": {
+                "type": "integer",
+                "minimum": 0,
+                "exclusiveMinimum": true
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "mode",
+              "normalizedQuery",
+              "page",
+              "limit",
+              "total"
+            ]
+          }
+        },
+        "required": [
+          "items",
+          "nextCursor",
+          "queryMeta"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/v1/works": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Curated work summaries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "translation": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "summary": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "classification": {
+                            "type": "string"
+                          },
+                          "textShape": {
+                            "type": "string"
+                          },
+                          "featured": {
+                            "type": "boolean",
+                            "default": false
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "translation",
+                          "classification",
+                          "textShape"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/works/{slug}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "slug",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Work detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "work": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "translation": {
+                          "type": "object",
+                          "nullable": true,
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "summary": {
+                          "type": "object",
+                          "nullable": true,
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "classification": {
+                          "type": "string"
+                        },
+                        "textShape": {
+                          "type": "string"
+                        },
+                        "featured": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "slug",
+                        "title",
+                        "translation",
+                        "classification",
+                        "textShape"
+                      ]
+                    },
+                    "sections": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "nodeType": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "translation": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "description": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "position": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "nodeType",
+                          "title",
+                          "translation",
+                          "description",
+                          "position"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "work",
+                    "sections"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Work not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/passages/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Passage detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "passageId": {
+                      "type": "string"
+                    },
+                    "workSlug": {
+                      "type": "string"
+                    },
+                    "workTitle": {
+                      "type": "string"
+                    },
+                    "structureLabel": {
+                      "type": "string"
+                    },
+                    "locatorLabel": {
+                      "type": "string"
+                    },
+                    "originalText": {
+                      "type": "string"
+                    },
+                    "pageStart": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "pageEnd": {
+                      "type": "integer",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "passageId",
+                    "workSlug",
+                    "workTitle",
+                    "structureLabel",
+                    "locatorLabel",
+                    "originalText",
+                    "pageStart",
+                    "pageEnd"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Passage not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/search/pangtis": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "q",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "work",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 50,
+              "default": 20
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Global pangti search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "passageId": {
+                            "type": "string"
+                          },
+                          "workSlug": {
+                            "type": "string"
+                          },
+                          "workTitle": {
+                            "type": "string"
+                          },
+                          "structureLabel": {
+                            "type": "string"
+                          },
+                          "locatorLabel": {
+                            "type": "string"
+                          },
+                          "originalText": {
+                            "type": "string"
+                          },
+                          "matchedBy": {
+                            "type": "string",
+                            "enum": [
+                              "gurmukhi",
+                              "latin-initials"
+                            ]
+                          },
+                          "matchedInitials": {
+                            "type": "string"
+                          },
+                          "score": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "passageId",
+                          "workSlug",
+                          "workTitle",
+                          "structureLabel",
+                          "locatorLabel",
+                          "originalText",
+                          "matchedBy",
+                          "matchedInitials",
+                          "score"
+                        ]
+                      }
+                    },
+                    "nextCursor": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "queryMeta": {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "gurmukhi",
+                            "latin-initials"
+                          ]
+                        },
+                        "normalizedQuery": {
+                          "type": "string"
+                        },
+                        "page": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "exclusiveMinimum": true
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "exclusiveMinimum": true
+                        },
+                        "total": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "normalizedQuery",
+                        "page",
+                        "limit",
+                        "total"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "nextCursor",
+                    "queryMeta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@giaan-khand/api",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "test": "tsx --test test/**/*.spec.ts",
+    "openapi:write": "tsx src/scripts/write-openapi.ts",
+    "db:init": "tsx src/scripts/init-product-db.ts",
+    "import:archive": "tsx src/scripts/import-archive-to-postgres.ts",
+    "index:pangtis": "tsx src/scripts/index-pangtis.ts"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.0.0",
+    "@fastify/swagger": "^9.5.1",
+    "@fastify/swagger-ui": "^5.2.2",
+    "@giaan-khand/contracts": "workspace:*",
+    "@giaan-khand/search-core": "workspace:*",
+    "dotenv": "^16.4.7",
+    "drizzle-orm": "^1.0.0-beta.1-8aabc28",
+    "fastify": "^5.2.1",
+    "fastify-type-provider-zod": "^4.0.2",
+    "pg": "^8.13.3",
+    "typesense": "^2.0.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "@types/pg": "^8.11.10"
+  }
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,25 @@
+import cors from '@fastify/cors'
+import Fastify from 'fastify'
+
+import type { SearchService, WorkRepository } from './services/contracts'
+import { registerV1Routes } from './routes/v1'
+
+export const createApiApp = async (dependencies: {
+  searchService: SearchService
+  workRepository: WorkRepository
+}) => {
+  const app = Fastify({
+    logger: false,
+  })
+
+  await app.register(cors, {
+    origin: true,
+  })
+
+  app.get('/health', async () => ({ ok: true }))
+
+  await registerV1Routes(app, dependencies)
+
+  return app
+}
+

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -1,0 +1,23 @@
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
+
+import { productSchema } from './schema'
+
+export const createProductPool = (connectionString = process.env.DATABASE_URL) => {
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is required to connect to the product PostgreSQL database.')
+  }
+
+  return new Pool({
+    connectionString,
+  })
+}
+
+export const createProductDatabaseClient = (connectionString = process.env.DATABASE_URL) =>
+  drizzle({
+    casing: 'snake_case',
+    client: createProductPool(connectionString),
+    schema: productSchema,
+  })
+
+export type ProductDatabaseClient = ReturnType<typeof createProductDatabaseClient>

--- a/apps/api/src/db/ensure-schema.ts
+++ b/apps/api/src/db/ensure-schema.ts
@@ -1,0 +1,94 @@
+import type { Pool } from 'pg'
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS product_works (
+  id text PRIMARY KEY,
+  slug text NOT NULL,
+  title jsonb NOT NULL,
+  translation jsonb,
+  classification text NOT NULL,
+  text_shape text NOT NULL,
+  summary jsonb,
+  metadata jsonb
+);
+
+CREATE TABLE IF NOT EXISTS product_structure_nodes (
+  id text PRIMARY KEY,
+  work_id text NOT NULL REFERENCES product_works(id),
+  parent_id text,
+  slug text NOT NULL,
+  node_type text NOT NULL,
+  title jsonb NOT NULL,
+  translation jsonb,
+  description jsonb,
+  position integer NOT NULL,
+  metadata jsonb
+);
+
+CREATE TABLE IF NOT EXISTS product_passages (
+  id text PRIMARY KEY,
+  work_id text NOT NULL REFERENCES product_works(id),
+  structure_node_id text NOT NULL REFERENCES product_structure_nodes(id),
+  slug text NOT NULL,
+  passage_type text NOT NULL,
+  position integer NOT NULL,
+  reference text,
+  metadata jsonb
+);
+
+CREATE TABLE IF NOT EXISTS product_passage_texts (
+  id text PRIMARY KEY,
+  passage_id text NOT NULL REFERENCES product_passages(id),
+  witness_id text NOT NULL,
+  slug text NOT NULL,
+  content_role text NOT NULL,
+  language_code text,
+  script_code text,
+  body text NOT NULL,
+  position integer NOT NULL,
+  page integer,
+  page_start integer,
+  page_end integer,
+  folio text,
+  folio_start text,
+  folio_end text,
+  local_index integer,
+  unit_start integer,
+  unit_end integer,
+  metadata jsonb
+);
+
+CREATE INDEX IF NOT EXISTS product_work_slug_index
+  ON product_works (slug);
+
+CREATE INDEX IF NOT EXISTS product_structure_node_slug_index
+  ON product_structure_nodes (slug);
+
+CREATE INDEX IF NOT EXISTS product_structure_node_work_parent_position_index
+  ON product_structure_nodes (work_id, parent_id, position);
+
+CREATE INDEX IF NOT EXISTS product_passage_slug_index
+  ON product_passages (slug);
+
+CREATE INDEX IF NOT EXISTS product_passage_node_position_index
+  ON product_passages (structure_node_id, position);
+
+CREATE INDEX IF NOT EXISTS product_passage_work_position_index
+  ON product_passages (work_id, position);
+
+CREATE INDEX IF NOT EXISTS product_passage_text_slug_index
+  ON product_passage_texts (slug);
+
+CREATE INDEX IF NOT EXISTS product_passage_text_passage_position_index
+  ON product_passage_texts (passage_id, position);
+
+CREATE INDEX IF NOT EXISTS product_passage_text_role_position_index
+  ON product_passage_texts (content_role, script_code, position);
+
+CREATE INDEX IF NOT EXISTS product_passage_text_page_range_index
+  ON product_passage_texts (page_start, page_end);
+`
+
+export const ensureProductSchema = async (pool: Pool) => {
+  await pool.query(SCHEMA_SQL)
+}

--- a/apps/api/src/db/import-archive.ts
+++ b/apps/api/src/db/import-archive.ts
@@ -1,0 +1,349 @@
+import { asc, sql } from 'drizzle-orm'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import type { Metadata } from '../../../../archive/src/types'
+
+import { archiveSchema, type ArchiveDatabaseClient } from '../lib/archive-source'
+import type { ProductDatabaseClient } from './client'
+import { passageTexts, passages, structureNodes, works } from './schema'
+
+const DEFAULT_BATCH_SIZE = Number(process.env.PRODUCT_IMPORT_BATCH_SIZE ?? 2_000)
+const DEFAULT_WORK_BATCH_SIZE = Number(process.env.PRODUCT_IMPORT_WORK_BATCH_SIZE ?? 5_000)
+const DEFAULT_STRUCTURE_NODE_BATCH_SIZE = Number(
+  process.env.PRODUCT_IMPORT_STRUCTURE_NODE_BATCH_SIZE ?? 5_000,
+)
+const DEFAULT_PASSAGE_BATCH_SIZE = Number(process.env.PRODUCT_IMPORT_PASSAGE_BATCH_SIZE ?? 5_000)
+const DEFAULT_PASSAGE_TEXT_BATCH_SIZE = Number(
+  process.env.PRODUCT_IMPORT_PASSAGE_TEXT_BATCH_SIZE ?? 3_000,
+)
+
+type ImportStats = {
+  works: number
+  structureNodes: number
+  passages: number
+  passageTexts: number
+}
+
+type TableConfig<TRow, TInsert> = {
+  label: keyof ImportStats
+  readBatch: (offset: number, limit: number) => Promise<TRow[]>
+  writeBatch: (rows: TInsert[]) => Promise<void>
+  mapRow: (row: TRow) => TInsert
+}
+
+type ArchiveWorkRow = InferSelectModel<typeof archiveSchema.works>
+type ArchiveStructureNodeRow = InferSelectModel<typeof archiveSchema.structureNodes>
+type ArchivePassageRow = InferSelectModel<typeof archiveSchema.passages>
+type ArchivePassageTextRow = {
+  id: string
+  passageId: string
+  witnessId: string
+  slug: string
+  contentRole: string
+  languageCode: string | null
+  scriptCode: string | null
+  body: string
+  position: number
+  page: number | null
+  pageStart: number | null
+  pageEnd: number | null
+  folio: string | null
+  folioStart: string | null
+  folioEnd: string | null
+  localIndex: number | null
+  unitStart: number | null
+  unitEnd: number | null
+  metadata: Metadata | null
+}
+
+const upsertWorks = async (
+  db: ProductDatabaseClient,
+  rows: InferInsertModel<typeof works>[],
+) => {
+  if (!rows.length) {
+    return
+  }
+
+  await db
+    .insert(works)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: works.id,
+      set: {
+        slug: works.slug,
+        title: works.title,
+        translation: works.translation,
+        classification: works.classification,
+        textShape: works.textShape,
+        summary: works.summary,
+        metadata: works.metadata,
+      },
+    })
+}
+
+const upsertStructureNodes = async (
+  db: ProductDatabaseClient,
+  rows: InferInsertModel<typeof structureNodes>[],
+) => {
+  if (!rows.length) {
+    return
+  }
+
+  await db
+    .insert(structureNodes)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: structureNodes.id,
+      set: {
+        workId: structureNodes.workId,
+        parentId: structureNodes.parentId,
+        slug: structureNodes.slug,
+        nodeType: structureNodes.nodeType,
+        title: structureNodes.title,
+        translation: structureNodes.translation,
+        description: structureNodes.description,
+        position: structureNodes.position,
+        metadata: structureNodes.metadata,
+      },
+    })
+}
+
+const upsertPassages = async (
+  db: ProductDatabaseClient,
+  rows: InferInsertModel<typeof passages>[],
+) => {
+  if (!rows.length) {
+    return
+  }
+
+  await db
+    .insert(passages)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: passages.id,
+      set: {
+        workId: passages.workId,
+        structureNodeId: passages.structureNodeId,
+        slug: passages.slug,
+        passageType: passages.passageType,
+        position: passages.position,
+        reference: passages.reference,
+        metadata: passages.metadata,
+      },
+    })
+}
+
+const upsertPassageTexts = async (
+  db: ProductDatabaseClient,
+  rows: InferInsertModel<typeof passageTexts>[],
+) => {
+  if (!rows.length) {
+    return
+  }
+
+  await db
+    .insert(passageTexts)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: passageTexts.id,
+      set: {
+        passageId: passageTexts.passageId,
+        witnessId: passageTexts.witnessId,
+        slug: passageTexts.slug,
+        contentRole: passageTexts.contentRole,
+        languageCode: passageTexts.languageCode,
+        scriptCode: passageTexts.scriptCode,
+        body: passageTexts.body,
+        position: passageTexts.position,
+        page: passageTexts.page,
+        pageStart: passageTexts.pageStart,
+        pageEnd: passageTexts.pageEnd,
+        folio: passageTexts.folio,
+        folioStart: passageTexts.folioStart,
+        folioEnd: passageTexts.folioEnd,
+        localIndex: passageTexts.localIndex,
+        unitStart: passageTexts.unitStart,
+        unitEnd: passageTexts.unitEnd,
+        metadata: passageTexts.metadata,
+      },
+    })
+}
+
+const importTable = async <TRow, TInsert>(
+  config: TableConfig<TRow, TInsert>,
+  batchSize = DEFAULT_BATCH_SIZE,
+) => {
+  let offset = 0
+  let total = 0
+
+  for (;;) {
+    const rows = await config.readBatch(offset, batchSize)
+
+    if (!rows.length) {
+      console.log(`[import] ${config.label}: ${total}`)
+      return total
+    }
+
+    await config.writeBatch(rows.map(config.mapRow))
+
+    total += rows.length
+    offset += rows.length
+
+    if (total % (batchSize * 5) === 0) {
+      console.log(`[import] ${config.label}: ${total}`)
+    }
+  }
+}
+
+export const importArchiveIntoProductDb = async (
+  archiveDb: ArchiveDatabaseClient,
+  productDb: ProductDatabaseClient,
+  batchSize = DEFAULT_BATCH_SIZE,
+): Promise<ImportStats> => {
+  const stats: ImportStats = {
+    works: 0,
+    structureNodes: 0,
+    passages: 0,
+    passageTexts: 0,
+  }
+
+  stats.works = await importTable<ArchiveWorkRow, InferInsertModel<typeof works>>(
+    {
+      label: 'works',
+      readBatch: (offset, limit) =>
+        archiveDb
+          .select()
+          .from(archiveSchema.works)
+          .orderBy(asc(archiveSchema.works.slug))
+          .limit(limit)
+          .offset(offset),
+      writeBatch: (rows) => upsertWorks(productDb, rows),
+      mapRow: (row) => ({
+        id: row.id,
+        slug: row.slug,
+        title: row.title,
+        translation: row.translation,
+        classification: row.classification,
+        textShape: row.textShape,
+        summary: row.summary,
+        metadata: row.metadata,
+      }),
+    },
+    Math.min(batchSize, DEFAULT_WORK_BATCH_SIZE),
+  )
+
+  stats.structureNodes = await importTable<
+    ArchiveStructureNodeRow,
+    InferInsertModel<typeof structureNodes>
+  >(
+    {
+      label: 'structureNodes',
+      readBatch: (offset, limit) =>
+        archiveDb
+          .select()
+          .from(archiveSchema.structureNodes)
+          .orderBy(asc(archiveSchema.structureNodes.id))
+          .limit(limit)
+          .offset(offset),
+      writeBatch: (rows) => upsertStructureNodes(productDb, rows),
+      mapRow: (row) => ({
+        id: row.id,
+        workId: row.workId,
+        parentId: row.parentId,
+        slug: row.slug,
+        nodeType: row.nodeType,
+        title: row.title,
+        translation: row.translation,
+        description: row.description,
+        position: row.position,
+        metadata: row.metadata,
+      }),
+    },
+    Math.min(batchSize, DEFAULT_STRUCTURE_NODE_BATCH_SIZE),
+  )
+
+  stats.passages = await importTable<ArchivePassageRow, InferInsertModel<typeof passages>>(
+    {
+      label: 'passages',
+      readBatch: (offset, limit) =>
+        archiveDb
+          .select()
+          .from(archiveSchema.passages)
+          .orderBy(asc(archiveSchema.passages.id))
+          .limit(limit)
+          .offset(offset),
+      writeBatch: (rows) => upsertPassages(productDb, rows),
+      mapRow: (row) => ({
+        id: row.id,
+        workId: row.workId,
+        structureNodeId: row.structureNodeId,
+        slug: row.slug,
+        passageType: row.passageType,
+        position: row.position,
+        reference: row.reference,
+        metadata: row.metadata,
+      }),
+    },
+    Math.min(batchSize, DEFAULT_PASSAGE_BATCH_SIZE),
+  )
+
+  stats.passageTexts = await importTable<
+    ArchivePassageTextRow,
+    InferInsertModel<typeof passageTexts>
+  >(
+    {
+      label: 'passageTexts',
+      readBatch: (offset, limit) =>
+        archiveDb
+          .select({
+            id: archiveSchema.passageTexts.id,
+            passageId: archiveSchema.passageTexts.passageId,
+            witnessId: archiveSchema.passageTexts.witnessId,
+            slug: archiveSchema.passageTexts.slug,
+            contentRole: archiveSchema.passageTexts.contentRole,
+            languageCode: archiveSchema.passageTexts.languageCode,
+            scriptCode: archiveSchema.passageTexts.scriptCode,
+            body: archiveSchema.passageTexts.body,
+            position: archiveSchema.passageTexts.position,
+            page: archiveSchema.passageTexts.page,
+            pageStart: sql<number | null>`null`.as('page_start'),
+            pageEnd: sql<number | null>`null`.as('page_end'),
+            folio: archiveSchema.passageTexts.folio,
+            folioStart: sql<string | null>`null`.as('folio_start'),
+            folioEnd: sql<string | null>`null`.as('folio_end'),
+            localIndex: archiveSchema.passageTexts.localIndex,
+            unitStart: sql<number | null>`null`.as('unit_start'),
+            unitEnd: sql<number | null>`null`.as('unit_end'),
+            metadata: archiveSchema.passageTexts.metadata,
+          })
+          .from(archiveSchema.passageTexts)
+          .orderBy(asc(archiveSchema.passageTexts.id))
+          .limit(limit)
+          .offset(offset),
+      writeBatch: (rows) => upsertPassageTexts(productDb, rows),
+      mapRow: (row) => ({
+        id: row.id,
+        passageId: row.passageId,
+        witnessId: row.witnessId,
+        slug: row.slug,
+        contentRole: row.contentRole,
+        languageCode: row.languageCode,
+        scriptCode: row.scriptCode,
+        body: row.body,
+        position: row.position,
+        page: row.page,
+        pageStart: row.pageStart,
+        pageEnd: row.pageEnd,
+        folio: row.folio,
+        folioStart: row.folioStart,
+        folioEnd: row.folioEnd,
+        localIndex: row.localIndex,
+        unitStart: row.unitStart,
+        unitEnd: row.unitEnd,
+        metadata: row.metadata,
+      }),
+    },
+    Math.min(batchSize, DEFAULT_PASSAGE_TEXT_BATCH_SIZE),
+  )
+
+  return stats
+}

--- a/apps/api/src/db/repositories.ts
+++ b/apps/api/src/db/repositories.ts
@@ -1,0 +1,157 @@
+import { and, asc, eq, isNull, type InferSelectModel } from 'drizzle-orm'
+
+import type {
+  PassageDetailResponse,
+  WorkDetailResponse,
+  WorksResponse,
+} from '@giaan-khand/contracts'
+
+import type { ProductDatabaseClient } from './client'
+import { passageTexts, passages, structureNodes, works } from './schema'
+
+const FEATURED_WORKS = ['guru-granth-sahib', 'dasam-granth', 'varan', 'divan-i-goya']
+
+const getDisplayText = (
+  value: Record<string, string> | null | undefined,
+  fallbacks: Array<string | null | undefined>,
+) => {
+  if (value?.Guru) {
+    return value.Guru
+  }
+
+  if (value?.Latn) {
+    return value.Latn
+  }
+
+  for (const fallback of fallbacks) {
+    if (fallback) {
+      return fallback
+    }
+  }
+
+  return ''
+}
+
+const toWorkSummary = (
+  row: InferSelectModel<typeof works>,
+  featured: boolean,
+): WorksResponse['items'][number] => ({
+  id: row.id,
+  slug: row.slug,
+  title: row.title,
+  translation: row.translation,
+  summary: row.summary,
+  classification: row.classification,
+  textShape: row.textShape,
+  featured,
+})
+
+const toLocatorLabel = (row: InferSelectModel<typeof passageTexts>, passagePosition: number) => {
+  if (row.pageStart && row.pageEnd && row.pageStart !== row.pageEnd) {
+    return `Pages ${row.pageStart}-${row.pageEnd}`
+  }
+
+  if (row.pageStart) {
+    return `Page ${row.pageStart}`
+  }
+
+  if (row.page) {
+    return `Page ${row.page}`
+  }
+
+  if (row.unitStart && row.unitEnd && row.unitStart !== row.unitEnd) {
+    return `Units ${row.unitStart}-${row.unitEnd}`
+  }
+
+  if (row.unitStart) {
+    return `Unit ${row.unitStart}`
+  }
+
+  return `Passage ${passagePosition}`
+}
+
+export const createPostgresWorkRepository = (db: ProductDatabaseClient) => ({
+  async listWorks(): Promise<WorksResponse> {
+    const rows = await db.select().from(works).orderBy(asc(works.slug))
+
+    const featured = FEATURED_WORKS.flatMap((slug) => rows.find((row) => row.slug === slug) ?? [])
+    const remaining = rows.filter((row) => !FEATURED_WORKS.includes(row.slug))
+
+    return {
+      items: [...featured, ...remaining].map((row) =>
+        toWorkSummary(row, FEATURED_WORKS.includes(row.slug)),
+      ),
+    }
+  },
+
+  async getWorkDetail(slug: string): Promise<WorkDetailResponse | null> {
+    const work = await db
+      .select()
+      .from(works)
+      .where(eq(works.slug, slug))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    if (!work) {
+      return null
+    }
+
+    const sections = await db
+      .select()
+      .from(structureNodes)
+      .where(and(eq(structureNodes.workId, work.id), isNull(structureNodes.parentId)))
+      .orderBy(asc(structureNodes.position))
+
+    return {
+      work: toWorkSummary(work, FEATURED_WORKS.includes(work.slug)),
+      sections: sections.map((section) => ({
+        id: section.id,
+        slug: section.slug,
+        nodeType: section.nodeType,
+        title: section.title,
+        translation: section.translation,
+        description: section.description,
+        position: section.position,
+      })),
+    }
+  },
+
+  async getPassageDetail(id: string): Promise<PassageDetailResponse | null> {
+    const row = await db
+      .select({
+        passage: passages,
+        text: passageTexts,
+        structureNode: structureNodes,
+        work: works,
+      })
+      .from(passages)
+      .innerJoin(
+        passageTexts,
+        and(eq(passageTexts.passageId, passages.id), eq(passageTexts.contentRole, 'original')),
+      )
+      .innerJoin(structureNodes, eq(structureNodes.id, passages.structureNodeId))
+      .innerJoin(works, eq(works.id, passages.workId))
+      .where(eq(passages.id, id))
+      .orderBy(asc(passageTexts.position))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    if (!row) {
+      return null
+    }
+
+    return {
+      passageId: row.passage.id,
+      workSlug: row.work.slug,
+      workTitle: getDisplayText(row.work.title, [row.work.translation?.en, row.work.slug]),
+      structureLabel: getDisplayText(row.structureNode.title, [
+        row.structureNode.translation?.en,
+        row.structureNode.slug,
+      ]),
+      locatorLabel: toLocatorLabel(row.text, row.passage.position),
+      originalText: row.text.body,
+      pageStart: row.text.pageStart ?? row.text.page ?? null,
+      pageEnd: row.text.pageEnd ?? row.text.page ?? null,
+    }
+  },
+})

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,0 +1,114 @@
+import { index, integer, jsonb, pgTable, text } from 'drizzle-orm/pg-core'
+
+import type { LanguageField, Metadata, ScriptField } from '../../../../archive/src/types'
+
+const json = <T>() => jsonb().$type<T>()
+
+export const works = pgTable(
+  'product_works',
+  {
+    id: text().primaryKey(),
+    slug: text().notNull(),
+    title: json<ScriptField>().notNull(),
+    translation: json<LanguageField | null>(),
+    classification: text().notNull(),
+    textShape: text().notNull(),
+    summary: json<LanguageField | null>(),
+    metadata: json<Metadata | null>(),
+  },
+  (table) => [index('product_work_slug_index').on(table.slug)],
+)
+
+export const structureNodes = pgTable(
+  'product_structure_nodes',
+  {
+    id: text().primaryKey(),
+    workId: text()
+      .notNull()
+      .references(() => works.id),
+    parentId: text(),
+    slug: text().notNull(),
+    nodeType: text().notNull(),
+    title: json<ScriptField>().notNull(),
+    translation: json<LanguageField | null>(),
+    description: json<LanguageField | null>(),
+    position: integer().notNull(),
+    metadata: json<Metadata | null>(),
+  },
+  (table) => [
+    index('product_structure_node_slug_index').on(table.slug),
+    index('product_structure_node_work_parent_position_index').on(
+      table.workId,
+      table.parentId,
+      table.position,
+    ),
+  ],
+)
+
+export const passages = pgTable(
+  'product_passages',
+  {
+    id: text().primaryKey(),
+    workId: text()
+      .notNull()
+      .references(() => works.id),
+    structureNodeId: text()
+      .notNull()
+      .references(() => structureNodes.id),
+    slug: text().notNull(),
+    passageType: text().notNull(),
+    position: integer().notNull(),
+    reference: text(),
+    metadata: json<Metadata | null>(),
+  },
+  (table) => [
+    index('product_passage_slug_index').on(table.slug),
+    index('product_passage_node_position_index').on(table.structureNodeId, table.position),
+    index('product_passage_work_position_index').on(table.workId, table.position),
+  ],
+)
+
+export const passageTexts = pgTable(
+  'product_passage_texts',
+  {
+    id: text().primaryKey(),
+    passageId: text()
+      .notNull()
+      .references(() => passages.id),
+    witnessId: text().notNull(),
+    slug: text().notNull(),
+    contentRole: text().notNull(),
+    languageCode: text(),
+    scriptCode: text(),
+    body: text().notNull(),
+    position: integer().notNull(),
+    page: integer(),
+    pageStart: integer(),
+    pageEnd: integer(),
+    folio: text(),
+    folioStart: text(),
+    folioEnd: text(),
+    localIndex: integer(),
+    unitStart: integer(),
+    unitEnd: integer(),
+    metadata: json<Metadata | null>(),
+  },
+  (table) => [
+    index('product_passage_text_slug_index').on(table.slug),
+    index('product_passage_text_passage_position_index').on(table.passageId, table.position),
+    index('product_passage_text_role_position_index').on(
+      table.contentRole,
+      table.scriptCode,
+      table.position,
+    ),
+    index('product_passage_text_page_range_index').on(table.pageStart, table.pageEnd),
+  ],
+)
+
+export const productSchema = {
+  works,
+  structureNodes,
+  passages,
+  passageTexts,
+}
+

--- a/apps/api/src/lib/archive-source.ts
+++ b/apps/api/src/lib/archive-source.ts
@@ -1,0 +1,14 @@
+import { createArchiveDatabaseClient, archiveSchema } from '../../../../archive/src/client'
+import type { ArchiveDatabaseClient } from '../../../../archive/src/client'
+
+export const createArchiveSourceClient = (path = process.env.ARCHIVE_DATABASE_PATH) => {
+  if (!path) {
+    return createArchiveDatabaseClient()
+  }
+
+  return createArchiveDatabaseClient({ path })
+}
+
+export { archiveSchema }
+export type { ArchiveDatabaseClient }
+

--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -1,0 +1,68 @@
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import { ZodError } from 'zod'
+
+import {
+  errorResponseSchema,
+  openApiDocument,
+  pangtiSearchQuerySchema,
+} from '@giaan-khand/contracts'
+
+import type { SearchService, WorkRepository } from '../services/contracts'
+
+const sendBadRequest = (reply: FastifyReply, error: Error) =>
+  reply.status(400).send(errorResponseSchema.parse({ error: error.message }))
+
+const sendNotFound = (reply: FastifyReply, message: string) =>
+  reply.status(404).send(errorResponseSchema.parse({ error: message }))
+
+export const registerV1Routes = async (
+  app: FastifyInstance,
+  dependencies: {
+    searchService: SearchService
+    workRepository: WorkRepository
+  },
+) => {
+  app.get('/openapi.json', async () => openApiDocument)
+
+  app.get('/v1/works', async (_request, reply) => {
+    const payload = await dependencies.workRepository.listWorks()
+    return reply.send(payload)
+  })
+
+  app.get('/v1/works/:slug', async (request, reply) => {
+    const slug = String((request.params as { slug: string }).slug)
+    const payload = await dependencies.workRepository.getWorkDetail(slug)
+
+    if (!payload) {
+      return sendNotFound(reply, 'Work not found')
+    }
+
+    return reply.send(payload)
+  })
+
+  app.get('/v1/passages/:id', async (request, reply) => {
+    const id = String((request.params as { id: string }).id)
+    const payload = await dependencies.workRepository.getPassageDetail(id)
+
+    if (!payload) {
+      return sendNotFound(reply, 'Passage not found')
+    }
+
+    return reply.send(payload)
+  })
+
+  app.get('/v1/search/pangtis', async (request, reply) => {
+    try {
+      const query = pangtiSearchQuerySchema.parse(request.query)
+      const payload = await dependencies.searchService.searchPangtis(query)
+
+      return reply.send(payload)
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return sendBadRequest(reply, new Error(error.issues.map((issue) => issue.message).join('; ')))
+      }
+
+      throw error
+    }
+  })
+}

--- a/apps/api/src/scripts/import-archive-to-postgres.ts
+++ b/apps/api/src/scripts/import-archive-to-postgres.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config'
+
+import { createProductDatabaseClient } from '../db/client'
+import { ensureProductSchema } from '../db/ensure-schema'
+import { importArchiveIntoProductDb } from '../db/import-archive'
+import { createArchiveSourceClient } from '../lib/archive-source'
+
+const archiveDb = createArchiveSourceClient()
+const productDb = createProductDatabaseClient()
+
+await ensureProductSchema(productDb.$client)
+
+const stats = await importArchiveIntoProductDb(archiveDb, productDb)
+
+console.log(JSON.stringify(stats, null, 2))

--- a/apps/api/src/scripts/index-pangtis.ts
+++ b/apps/api/src/scripts/index-pangtis.ts
@@ -1,0 +1,74 @@
+import 'dotenv/config'
+
+import { and, asc, eq } from 'drizzle-orm'
+import Typesense from 'typesense'
+import type { CollectionCreateSchema } from 'typesense/lib/Typesense/Collections'
+
+import { createProductDatabaseClient } from '../db/client'
+import { passageTexts, passages, structureNodes, works } from '../db/schema'
+import { buildPangtiDocument } from '../services/pangti-document'
+
+const client = new Typesense.Client({
+  nodes: [
+    {
+      host: process.env.TYPESENSE_HOST ?? 'localhost',
+      port: Number(process.env.TYPESENSE_PORT ?? '8108'),
+      protocol: process.env.TYPESENSE_PROTOCOL ?? 'http',
+    },
+  ],
+  apiKey: process.env.TYPESENSE_API_KEY ?? 'xyz',
+  connectionTimeoutSeconds: 10,
+})
+
+const COLLECTION_NAME = 'pangtis'
+
+const db = createProductDatabaseClient()
+
+const schema: CollectionCreateSchema = {
+  name: COLLECTION_NAME,
+  fields: [
+    { name: 'id', type: 'string' },
+    { name: 'passageId', type: 'string' },
+    { name: 'workSlug', type: 'string', facet: true },
+    { name: 'workTitle', type: 'string' },
+    { name: 'structureSlug', type: 'string' },
+    { name: 'structureLabel', type: 'string' },
+    { name: 'locatorLabel', type: 'string' },
+    { name: 'originalText', type: 'string' },
+    { name: 'normalizedText', type: 'string' },
+    { name: 'gurmukhiInitials', type: 'string' },
+    { name: 'latinInitials', type: 'string' },
+    { name: 'pageStart', type: 'int32', optional: true },
+    { name: 'pageEnd', type: 'int32', optional: true },
+    { name: 'workPosition', type: 'int32' },
+  ],
+  default_sorting_field: 'workPosition',
+}
+
+try {
+  await client.collections(COLLECTION_NAME).retrieve()
+} catch {
+  await client.collections().create(schema)
+}
+
+const rows = await db
+  .select({
+    passage: passages,
+    text: passageTexts,
+    structureNode: structureNodes,
+    work: works,
+  })
+  .from(passageTexts)
+  .innerJoin(passages, eq(passages.id, passageTexts.passageId))
+  .innerJoin(structureNodes, eq(structureNodes.id, passages.structureNodeId))
+  .innerJoin(works, eq(works.id, passages.workId))
+  .where(and(eq(passageTexts.contentRole, 'original'), eq(passageTexts.scriptCode, 'Guru')))
+  .orderBy(asc(passageTexts.id))
+
+const documents = rows.map(buildPangtiDocument)
+
+await client.collections(COLLECTION_NAME).documents().import(documents, {
+  action: 'upsert',
+})
+
+console.log(`Indexed ${documents.length} pangtis into ${COLLECTION_NAME}.`)

--- a/apps/api/src/scripts/init-product-db.ts
+++ b/apps/api/src/scripts/init-product-db.ts
@@ -1,0 +1,10 @@
+import 'dotenv/config'
+
+import { createProductDatabaseClient } from '../db/client'
+import { ensureProductSchema } from '../db/ensure-schema'
+
+const db = createProductDatabaseClient()
+
+await ensureProductSchema(db.$client)
+
+console.log('Product PostgreSQL schema is ready.')

--- a/apps/api/src/scripts/write-openapi.ts
+++ b/apps/api/src/scripts/write-openapi.ts
@@ -1,0 +1,11 @@
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { openApiDocument } from '@giaan-khand/contracts'
+
+const outputPath = resolve(process.cwd(), 'openapi.json')
+
+await writeFile(outputPath, JSON.stringify(openApiDocument, null, 2))
+
+console.log(`Wrote OpenAPI document to ${outputPath}`)
+

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config'
+
+import { createProductDatabaseClient } from './db/client'
+import { createPostgresWorkRepository } from './db/repositories'
+import { createApiApp } from './app'
+import { createTypesenseSearchService } from './services/typesense-search'
+
+const port = Number(process.env.API_PORT ?? 4000)
+
+const db = createProductDatabaseClient()
+const workRepository = createPostgresWorkRepository(db)
+const searchService = createTypesenseSearchService()
+
+const app = await createApiApp({
+  searchService,
+  workRepository,
+})
+
+await app.listen({
+  host: '0.0.0.0',
+  port,
+})
+

--- a/apps/api/src/services/contracts.ts
+++ b/apps/api/src/services/contracts.ts
@@ -1,0 +1,18 @@
+import type {
+  PangtiSearchQuery,
+  PangtiSearchResponse,
+  PassageDetailResponse,
+  WorkDetailResponse,
+  WorksResponse,
+} from '@giaan-khand/contracts'
+
+export type SearchService = {
+  searchPangtis(query: PangtiSearchQuery): Promise<PangtiSearchResponse>
+}
+
+export type WorkRepository = {
+  listWorks(): Promise<WorksResponse>
+  getWorkDetail(slug: string): Promise<WorkDetailResponse | null>
+  getPassageDetail(id: string): Promise<PassageDetailResponse | null>
+}
+

--- a/apps/api/src/services/pangti-document.ts
+++ b/apps/api/src/services/pangti-document.ts
@@ -1,0 +1,110 @@
+import type { InferSelectModel } from 'drizzle-orm'
+
+import {
+  buildSearchDocumentFields,
+  detectQueryMode,
+  normalizeLatinInitialQuery,
+  type QueryMode,
+} from '@giaan-khand/search-core'
+
+import { passageTexts, passages, structureNodes, works } from '../db/schema'
+
+export type PangtiIndexRow = {
+  passage: InferSelectModel<typeof passages>
+  text: InferSelectModel<typeof passageTexts>
+  structureNode: InferSelectModel<typeof structureNodes>
+  work: InferSelectModel<typeof works>
+}
+
+export type PangtiDocument = {
+  id: string
+  passageId: string
+  workSlug: string
+  workTitle: string
+  structureSlug: string
+  structureLabel: string
+  locatorLabel: string
+  originalText: string
+  normalizedText: string
+  gurmukhiInitials: string
+  latinInitials: string
+  pageStart: number
+  pageEnd: number
+  workPosition: number
+}
+
+const toWorkTitle = (title: Record<string, string>, translation: Record<string, string> | null) =>
+  title.Guru ?? title.Latn ?? translation?.en ?? 'Untitled'
+
+const toStructureLabel = (
+  title: Record<string, string>,
+  translation: Record<string, string> | null,
+  fallback: string,
+) => title.Guru ?? title.Latn ?? translation?.en ?? fallback
+
+const toLocatorLabel = (row: PangtiIndexRow) => {
+  if (row.text.pageStart && row.text.pageEnd && row.text.pageStart !== row.text.pageEnd) {
+    return `Pages ${row.text.pageStart}-${row.text.pageEnd}`
+  }
+
+  if (row.text.pageStart) {
+    return `Page ${row.text.pageStart}`
+  }
+
+  if (row.text.page) {
+    return `Page ${row.text.page}`
+  }
+
+  if (row.text.unitStart && row.text.unitEnd && row.text.unitStart !== row.text.unitEnd) {
+    return `Units ${row.text.unitStart}-${row.text.unitEnd}`
+  }
+
+  if (row.text.unitStart) {
+    return `Unit ${row.text.unitStart}`
+  }
+
+  return `Passage ${row.passage.position}`
+}
+
+export const buildPangtiDocument = (row: PangtiIndexRow): PangtiDocument => {
+  const searchFields = buildSearchDocumentFields(row.text.body)
+
+  return {
+    id: row.text.id,
+    passageId: row.passage.id,
+    workSlug: row.work.slug,
+    workTitle: toWorkTitle(row.work.title, row.work.translation),
+    structureSlug: row.structureNode.slug,
+    structureLabel: toStructureLabel(
+      row.structureNode.title,
+      row.structureNode.translation,
+      row.structureNode.slug,
+    ),
+    locatorLabel: toLocatorLabel(row),
+    originalText: row.text.body,
+    normalizedText: searchFields.normalizedText,
+    gurmukhiInitials: searchFields.gurmukhiInitials,
+    latinInitials: searchFields.latinInitials,
+    pageStart: row.text.pageStart ?? row.text.page ?? 0,
+    pageEnd: row.text.pageEnd ?? row.text.page ?? 0,
+    workPosition: row.passage.position,
+  }
+}
+
+export const buildTypesenseQuery = (query: string) => {
+  const mode = detectQueryMode(query)
+  const normalizedQuery =
+    mode === 'latin-initials' ? normalizeLatinInitialQuery(query) : buildSearchDocumentFields(query).normalizedText
+
+  return {
+    mode,
+    normalizedQuery,
+    queryBy: mode === 'latin-initials' ? 'latinInitials' : 'normalizedText',
+    prefix: mode === 'latin-initials',
+  } satisfies {
+    mode: QueryMode
+    normalizedQuery: string
+    queryBy: 'latinInitials' | 'normalizedText'
+    prefix: boolean
+  }
+}

--- a/apps/api/src/services/typesense-search.ts
+++ b/apps/api/src/services/typesense-search.ts
@@ -1,0 +1,87 @@
+import Typesense from 'typesense'
+
+import type { PangtiSearchQuery, PangtiSearchResponse } from '@giaan-khand/contracts'
+
+import type { SearchService } from './contracts'
+import { buildTypesenseQuery } from './pangti-document'
+
+const COLLECTION_NAME = 'pangtis'
+
+const encodeCursor = (page: number) => Buffer.from(JSON.stringify({ page }), 'utf8').toString('base64url')
+
+const decodeCursor = (cursor?: string | null) => {
+  if (!cursor) {
+    return 1
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as { page?: number }
+    return parsed.page && parsed.page > 0 ? parsed.page : 1
+  } catch {
+    return 1
+  }
+}
+
+export const createTypesenseSearchClient = () =>
+  new Typesense.Client({
+    nodes: [
+      {
+        host: process.env.TYPESENSE_HOST ?? 'localhost',
+        port: Number(process.env.TYPESENSE_PORT ?? '8108'),
+        protocol: process.env.TYPESENSE_PROTOCOL ?? 'http',
+      },
+    ],
+    apiKey: process.env.TYPESENSE_API_KEY ?? 'xyz',
+    connectionTimeoutSeconds: 10,
+  })
+
+export const createTypesenseSearchService = (
+  client = createTypesenseSearchClient(),
+): SearchService => ({
+  async searchPangtis(query: PangtiSearchQuery): Promise<PangtiSearchResponse> {
+    const page = decodeCursor(query.cursor)
+    const perPage = Math.max(1, Math.min(query.limit ?? 20, 50))
+    const search = buildTypesenseQuery(query.q)
+
+    const result = await client.collections(COLLECTION_NAME).documents().search({
+      q: search.normalizedQuery,
+      query_by: search.queryBy,
+      filter_by: query.work ? `workSlug:=${query.work}` : undefined,
+      prefix: search.prefix,
+      page,
+      per_page: perPage,
+      sort_by: '_text_match:desc,workPosition:asc',
+      highlight_fields: 'none',
+    })
+
+    const found = result.found ?? 0
+    const nextPage = page * perPage < found ? page + 1 : null
+
+    return {
+      items:
+        result.hits?.map((hit) => {
+          const document = hit.document as Record<string, string | number>
+
+          return {
+            passageId: String(document.passageId),
+            workSlug: String(document.workSlug),
+            workTitle: String(document.workTitle),
+            structureLabel: String(document.structureLabel),
+            locatorLabel: String(document.locatorLabel),
+            originalText: String(document.originalText),
+            matchedBy: search.mode,
+            matchedInitials: String(document.gurmukhiInitials),
+            score: hit.text_match ?? 0,
+          }
+        }) ?? [],
+      nextCursor: nextPage ? encodeCursor(nextPage) : null,
+      queryMeta: {
+        mode: search.mode,
+        normalizedQuery: search.normalizedQuery,
+        page,
+        limit: perPage,
+        total: found,
+      },
+    }
+  },
+})

--- a/apps/api/test/app.spec.ts
+++ b/apps/api/test/app.spec.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type {
+  PangtiSearchQuery,
+  PangtiSearchResponse,
+  PassageDetailResponse,
+  WorkDetailResponse,
+  WorksResponse,
+} from '@giaan-khand/contracts'
+
+import { createApiApp } from '../src/app'
+
+const fakeWorksResponse: WorksResponse = {
+  items: [
+    {
+      id: 'work-1',
+      slug: 'guru-granth-sahib',
+      title: {
+        Guru: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+      },
+      translation: {
+        en: 'Guru Granth Sahib',
+      },
+      summary: {
+        en: 'The central Sikh scripture.',
+      },
+      classification: 'scripture',
+      textShape: 'verse',
+      featured: true,
+    },
+  ],
+}
+
+const fakeWorkDetail: WorkDetailResponse = {
+  work: fakeWorksResponse.items[0],
+  sections: [
+    {
+      id: 'section-1',
+      slug: 'japji-sahib',
+      nodeType: 'composition',
+      title: {
+        Guru: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+      },
+      translation: {
+        en: 'Japji Sahib',
+      },
+      description: null,
+      position: 1,
+    },
+  ],
+}
+
+const fakePassage: PassageDetailResponse = {
+  passageId: 'passage-1',
+  workSlug: 'guru-granth-sahib',
+  workTitle: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+  structureLabel: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+  locatorLabel: 'Page 1',
+  originalText: 'ਇਕ ਓਅੰਕਾਰ ਸਤਿਨਾਮੁ',
+  pageStart: 1,
+  pageEnd: 1,
+}
+
+const fakeSearchResponse: PangtiSearchResponse = {
+  items: [
+    {
+      passageId: 'passage-1',
+      workSlug: 'guru-granth-sahib',
+      workTitle: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+      structureLabel: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+      locatorLabel: 'Page 1',
+      originalText: 'ਇਕ ਓਅੰਕਾਰ ਸਤਿਨਾਮੁ',
+      matchedBy: 'latin-initials',
+      matchedInitials: 'ਇਓਸ',
+      score: 100,
+    },
+  ],
+  nextCursor: null,
+  queryMeta: {
+    mode: 'latin-initials',
+    normalizedQuery: 'ios',
+    page: 1,
+    limit: 20,
+    total: 1,
+  },
+}
+
+const createFakeApp = () =>
+  createApiApp({
+    workRepository: {
+      listWorks: async () => fakeWorksResponse,
+      getWorkDetail: async (slug: string) => (slug === fakeWorkDetail.work.slug ? fakeWorkDetail : null),
+      getPassageDetail: async (id: string) => (id === fakePassage.passageId ? fakePassage : null),
+    },
+    searchService: {
+      searchPangtis: async (query: PangtiSearchQuery) => ({
+        ...fakeSearchResponse,
+        queryMeta: {
+          ...fakeSearchResponse.queryMeta,
+          normalizedQuery: query.q,
+        },
+      }),
+    },
+  })
+
+test('GET /v1/works returns work summaries', async () => {
+  const app = await createFakeApp()
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/works',
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.deepEqual(response.json(), fakeWorksResponse)
+
+  await app.close()
+})
+
+test('GET /v1/works/:slug returns one work detail', async () => {
+  const app = await createFakeApp()
+  const response = await app.inject({
+    method: 'GET',
+    url: `/v1/works/${fakeWorkDetail.work.slug}`,
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.deepEqual(response.json(), fakeWorkDetail)
+
+  await app.close()
+})
+
+test('GET /v1/passages/:id returns passage detail', async () => {
+  const app = await createFakeApp()
+  const response = await app.inject({
+    method: 'GET',
+    url: `/v1/passages/${fakePassage.passageId}`,
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.deepEqual(response.json(), fakePassage)
+
+  await app.close()
+})
+
+test('GET /v1/search/pangtis validates and returns search results', async () => {
+  const app = await createFakeApp()
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/search/pangtis?q=ਇਕ',
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.match((response.json() as PangtiSearchResponse).items[0]?.originalText ?? '', /ਇਕ/)
+
+  await app.close()
+})
+
+test('GET /v1/search/pangtis rejects an empty query', async () => {
+  const app = await createFakeApp()
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/search/pangtis?q=',
+  })
+
+  assert.equal(response.statusCode, 400)
+
+  await app.close()
+})

--- a/apps/api/test/fixtures/pangti.ts
+++ b/apps/api/test/fixtures/pangti.ts
@@ -1,0 +1,152 @@
+export const pangtiFixtures = {
+  works: [
+    {
+      id: 'work-1',
+      slug: 'guru-granth-sahib',
+      title: {
+        Guru: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+        Latn: 'Guru Granth Sahib',
+      },
+      translation: {
+        en: 'Guru Granth Sahib',
+      },
+      summary: {
+        en: 'The central Sikh scripture.',
+      },
+      classification: 'scripture',
+      textShape: 'verse',
+      metadata: null,
+    },
+    {
+      id: 'work-2',
+      slug: 'dasam-granth',
+      title: {
+        Guru: 'ਦਸਮ ਗ੍ਰੰਥ',
+        Latn: 'Dasam Granth',
+      },
+      translation: {
+        en: 'Dasam Granth',
+      },
+      summary: {
+        en: 'The Sikh text attributed to Guru Gobind Singh.',
+      },
+      classification: 'scripture',
+      textShape: 'verse',
+      metadata: null,
+    },
+  ],
+  structureNodes: [
+    {
+      id: 'section-1',
+      workId: 'work-1',
+      parentId: null,
+      slug: 'japji-sahib',
+      nodeType: 'composition',
+      title: {
+        Guru: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+        Latn: 'Japji Sahib',
+      },
+      translation: {
+        en: 'Japji Sahib',
+      },
+      description: {
+        en: 'Morning prayer',
+      },
+      position: 1,
+      metadata: null,
+    },
+    {
+      id: 'section-2',
+      workId: 'work-2',
+      parentId: null,
+      slug: 'bachitra-natak',
+      nodeType: 'composition',
+      title: {
+        Guru: 'ਬਚਿੱਤਰ ਨਾਟਕ',
+        Latn: 'Bachitra Natak',
+      },
+      translation: {
+        en: 'Bachitra Natak',
+      },
+      description: {
+        en: 'Narrative composition',
+      },
+      position: 1,
+      metadata: null,
+    },
+  ],
+  passages: [
+    {
+      id: 'passage-1',
+      workId: 'work-1',
+      structureNodeId: 'section-1',
+      slug: 'passage-1',
+      passageType: 'pangti',
+      position: 1,
+      reference: '1',
+      metadata: null,
+    },
+    {
+      id: 'passage-2',
+      workId: 'work-2',
+      structureNodeId: 'section-2',
+      slug: 'passage-2',
+      passageType: 'pangti',
+      position: 8,
+      reference: '8',
+      metadata: null,
+    },
+  ],
+  passageTexts: [
+    {
+      id: 'text-1',
+      passageId: 'passage-1',
+      witnessId: 'witness-1',
+      slug: 'text-1',
+      contentRole: 'original',
+      languageCode: 'pa',
+      scriptCode: 'Guru',
+      body: 'ਦਇਆ ਕਰਹੁ ਗੋਬਿੰਦ',
+      position: 1,
+      page: null,
+      pageStart: 1,
+      pageEnd: 2,
+      folio: null,
+      folioStart: null,
+      folioEnd: null,
+      localIndex: 3,
+      unitStart: null,
+      unitEnd: null,
+      citationId: null,
+      metadata: null,
+    },
+    {
+      id: 'text-2',
+      passageId: 'passage-2',
+      witnessId: 'witness-2',
+      slug: 'text-2',
+      contentRole: 'original',
+      languageCode: 'pa',
+      scriptCode: 'Guru',
+      body: 'ਇਕ ਓਅੰਕਾਰ ਸਤਿਨਾਮੁ',
+      position: 1,
+      page: 4,
+      pageStart: 4,
+      pageEnd: 4,
+      folio: null,
+      folioStart: null,
+      folioEnd: null,
+      localIndex: 1,
+      unitStart: null,
+      unitEnd: null,
+      citationId: null,
+      metadata: null,
+    },
+  ],
+}
+
+export const pangtiQueryFixtures = {
+  directQuery: 'ਦਇਆ ਕਰਹੁ ਗੋਬਿੰਦ',
+  latinQuery: 'dkg',
+  aliasQuery: 'D K G',
+}

--- a/apps/api/test/import-archive.spec.ts
+++ b/apps/api/test/import-archive.spec.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { archiveSchema } from '../src/lib/archive-source'
+import { importArchiveIntoProductDb } from '../src/db/import-archive'
+import { passageTexts, passages, structureNodes, works } from '../src/db/schema'
+import { pangtiFixtures } from './fixtures/pangti'
+
+type TableName = 'works' | 'structureNodes' | 'passages' | 'passageTexts'
+
+const getTableName = (table: object): TableName => {
+  if (table === archiveSchema.works || table === works) {
+    return 'works'
+  }
+
+  if (table === archiveSchema.structureNodes || table === structureNodes) {
+    return 'structureNodes'
+  }
+
+  if (table === archiveSchema.passages || table === passages) {
+    return 'passages'
+  }
+
+  if (table === archiveSchema.passageTexts || table === passageTexts) {
+    return 'passageTexts'
+  }
+
+  throw new Error('Unknown table')
+}
+
+const createArchiveDb = () => {
+  const datasets: Record<TableName, unknown[]> = {
+    works: pangtiFixtures.works,
+    structureNodes: pangtiFixtures.structureNodes,
+    passages: pangtiFixtures.passages,
+    passageTexts: pangtiFixtures.passageTexts,
+  }
+
+  const makeQuery = (tableName: TableName) => {
+    let limit = Number.POSITIVE_INFINITY
+
+    const query = {
+      orderBy: () => query,
+      limit: (value: number) => {
+        limit = value
+        return query
+      },
+      offset: (offset: number) =>
+        Promise.resolve(datasets[tableName].slice(offset, offset + limit) as never[]),
+    }
+
+    return query
+  }
+
+  return {
+    select: () => ({
+      from: (table: object) => makeQuery(getTableName(table)),
+    }),
+  }
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const createProductDb = () => {
+  const calls: Array<{ table: TableName; rows: unknown[] }> = []
+
+  const makeInsert = (tableName: TableName) => ({
+    values: (rows: unknown[]) => {
+      calls.push({ table: tableName, rows: clone(rows) })
+
+      return {
+        onConflictDoUpdate: async () => undefined,
+      }
+    },
+  })
+
+  return {
+    calls,
+    db: {
+      insert: (table: object) => makeInsert(getTableName(table)),
+    },
+  }
+}
+
+const flattenRowsByTable = (calls: Array<{ table: TableName; rows: unknown[] }>) =>
+  calls.reduce<Record<TableName, unknown[]>>(
+    (accumulator, call) => {
+      accumulator[call.table].push(...call.rows)
+      return accumulator
+    },
+    {
+      works: [],
+      structureNodes: [],
+      passages: [],
+      passageTexts: [],
+    },
+  )
+
+const importedPassageTexts = pangtiFixtures.passageTexts.map(
+  ({ citationId: _citationId, ...row }) => row,
+)
+
+test('importArchiveIntoProductDb maps archive rows into stable product upserts', async () => {
+  const archiveDb = createArchiveDb()
+  const product = createProductDb()
+
+  const stats = await importArchiveIntoProductDb(archiveDb as never, product.db as never, 1)
+
+  assert.deepEqual(stats, {
+    works: 2,
+    structureNodes: 2,
+    passages: 2,
+    passageTexts: 2,
+  })
+
+  assert.deepEqual(flattenRowsByTable(product.calls), {
+    works: pangtiFixtures.works,
+    structureNodes: pangtiFixtures.structureNodes,
+    passages: pangtiFixtures.passages,
+    passageTexts: importedPassageTexts,
+  })
+})
+
+test('importArchiveIntoProductDb emits the same upsert shape on repeated runs', async () => {
+  const archiveDb = createArchiveDb()
+  const firstRun = createProductDb()
+  const secondRun = createProductDb()
+
+  await importArchiveIntoProductDb(archiveDb as never, firstRun.db as never, 1)
+  await importArchiveIntoProductDb(archiveDb as never, secondRun.db as never, 1)
+
+  assert.deepEqual(firstRun.calls, secondRun.calls)
+})

--- a/apps/api/test/pangti-document.spec.ts
+++ b/apps/api/test/pangti-document.spec.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildSearchDocumentFields, normalizeLatinInitialQuery } from '@giaan-khand/search-core'
+
+import { buildPangtiDocument, buildTypesenseQuery } from '../src/services/pangti-document'
+import { pangtiFixtures, pangtiQueryFixtures } from './fixtures/pangti'
+
+const pangtiRow = {
+  passage: pangtiFixtures.passages[0],
+  text: pangtiFixtures.passageTexts[0],
+  structureNode: pangtiFixtures.structureNodes[0],
+  work: pangtiFixtures.works[0],
+}
+
+test('buildPangtiDocument indexes the pangti with matching initials and locators', () => {
+  const document = buildPangtiDocument(pangtiRow as never)
+  const searchFields = buildSearchDocumentFields(pangtiFixtures.passageTexts[0].body)
+
+  assert.deepEqual(
+    {
+      id: document.id,
+      passageId: document.passageId,
+      workSlug: document.workSlug,
+      workTitle: document.workTitle,
+      structureSlug: document.structureSlug,
+      structureLabel: document.structureLabel,
+      locatorLabel: document.locatorLabel,
+      originalText: document.originalText,
+      normalizedText: document.normalizedText,
+      gurmukhiInitials: document.gurmukhiInitials,
+      latinInitials: document.latinInitials,
+      pageStart: document.pageStart,
+      pageEnd: document.pageEnd,
+      workPosition: document.workPosition,
+    },
+    {
+      id: 'text-1',
+      passageId: 'passage-1',
+      workSlug: 'guru-granth-sahib',
+      workTitle: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+      structureSlug: 'japji-sahib',
+      structureLabel: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+      locatorLabel: 'Pages 1-2',
+      originalText: pangtiFixtures.passageTexts[0].body,
+      normalizedText: searchFields.normalizedText,
+      gurmukhiInitials: searchFields.gurmukhiInitials,
+      latinInitials: searchFields.latinInitials,
+      pageStart: 1,
+      pageEnd: 2,
+      workPosition: 1,
+    },
+  )
+})
+
+test('buildTypesenseQuery routes direct Gurmukhi and Latin initials to the same pangti intent', () => {
+  const directQuery = buildTypesenseQuery(pangtiQueryFixtures.directQuery)
+  const latinQuery = buildTypesenseQuery(pangtiQueryFixtures.latinQuery)
+  const aliasQuery = buildTypesenseQuery(pangtiQueryFixtures.aliasQuery)
+
+  assert.deepEqual(directQuery, {
+    mode: 'gurmukhi',
+    normalizedQuery: buildSearchDocumentFields(pangtiQueryFixtures.directQuery).normalizedText,
+    queryBy: 'normalizedText',
+    prefix: false,
+  })
+
+  assert.deepEqual(latinQuery, {
+    mode: 'latin-initials',
+    normalizedQuery: normalizeLatinInitialQuery(pangtiQueryFixtures.latinQuery),
+    queryBy: 'latinInitials',
+    prefix: true,
+  })
+
+  assert.deepEqual(aliasQuery, {
+    mode: 'latin-initials',
+    normalizedQuery: 'dkg',
+    queryBy: 'latinInitials',
+    prefix: true,
+  })
+
+  assert.equal(
+    buildPangtiDocument(pangtiRow as never).latinInitials,
+    latinQuery.normalizedQuery,
+  )
+})

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,5 @@
+.next
+node_modules
+out
+.DS_Store
+*.tsbuildinfo

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,45 @@
+@import url('../src/styles/tokens.css');
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(214, 168, 72, 0.08), transparent 38%),
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.03), transparent 22%),
+    var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 0;
+}
+
+::selection {
+  background: rgba(214, 168, 72, 0.3);
+  color: #fff;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next'
+import { Inter, Noto_Sans_Gurmukhi } from 'next/font/google'
+
+import './globals.css'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+})
+
+const gurmukhi = Noto_Sans_Gurmukhi({
+  subsets: ['gurmukhi'],
+  variable: '--font-gurmukhi',
+  weight: ['400', '500', '600', '700'],
+})
+
+export const metadata: Metadata = {
+  title: 'Giaan Khand',
+  description: 'Search Sikh scripture with a premium pangti-first browsing experience.',
+}
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en" className={`${inter.variable} ${gurmukhi.variable}`}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+
+import { buildSearchHref } from '@/lib/routes'
+
+export default function NotFound() {
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+        padding: '2rem',
+        color: 'white',
+      }}
+    >
+      <div style={{ textAlign: 'center', maxWidth: '32rem' }}>
+        <p style={{ color: '#888', marginBottom: '0.5rem' }}>Not found</p>
+        <h1 style={{ margin: 0, fontSize: '2rem', fontWeight: 600 }}>That page is not available.</h1>
+        <p style={{ color: '#777', marginTop: '0.75rem' }}>
+          Return to the search surface or try another work.
+        </p>
+        <Link
+          href={buildSearchHref('')}
+          style={{
+            display: 'inline-flex',
+            marginTop: '1.25rem',
+            padding: '0.75rem 1rem',
+            borderRadius: '999px',
+            background: '#151515',
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          Back to search
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,10 @@
+import { SearchExperience } from '@/components/search/search-experience'
+import { createApiClient } from '@giaan-khand/sdk'
+
+const client = createApiClient()
+
+export default async function HomePage() {
+  const featuredWorks = await client.listWorks().then((response) => response.items).catch(() => [])
+
+  return <SearchExperience featuredWorks={featuredWorks} initialQuery="" mode="home" />
+}

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from 'next/navigation'
+
+import { SearchExperience } from '@/components/search/search-experience'
+import { createApiClient } from '@giaan-khand/sdk'
+
+const client = createApiClient()
+
+type SearchPageProps = {
+  searchParams: Promise<{
+    q?: string | string[]
+  }>
+}
+
+const getFirstValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] ?? '' : value ?? ''
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const { q } = await searchParams
+  const query = getFirstValue(q).trim()
+
+  if (!query) {
+    redirect('/')
+  }
+
+  const [featuredWorks, initialResults] = await Promise.all([
+    client.listWorks().then((response) => response.items).catch(() => []),
+    client.searchPangtis({ q: query, limit: 24 }).then((response) => response.items).catch(() => []),
+  ])
+
+  return (
+    <SearchExperience
+      featuredWorks={featuredWorks}
+      initialQuery={query}
+      initialResults={initialResults}
+      mode="search"
+    />
+  )
+}

--- a/apps/web/app/works/[slug]/page.tsx
+++ b/apps/web/app/works/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation'
+import { createApiClient } from '@giaan-khand/sdk'
+
+import { WorkDetail } from '@/components/work/work-detail'
+
+const client = createApiClient()
+
+type WorkPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+  searchParams: Promise<{
+    q?: string | string[]
+  }>
+}
+
+const getFirstValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] ?? '' : value ?? ''
+
+export default async function WorkPage({ params, searchParams }: WorkPageProps) {
+  const { slug } = await params
+  const { q } = await searchParams
+  const query = getFirstValue(q).trim()
+
+  try {
+    const { work, sections } = await client.getWork(slug)
+
+    return <WorkDetail work={work} sections={sections} searchQuery={query} />
+  } catch {
+    notFound()
+  }
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,10 @@
+import { fileURLToPath } from 'node:url'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  typedRoutes: true,
+  outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
+  transpilePackages: ['@giaan-khand/sdk', '@giaan-khand/contracts'],
+}
+
+export default nextConfig

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@giaan-khand/web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.spec.ts"
+  },
+  "dependencies": {
+    "@giaan-khand/sdk": "workspace:*",
+    "next": "^15.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/apps/web/src/components/search/search-experience.module.css
+++ b/apps/web/src/components/search/search-experience.module.css
@@ -1,0 +1,514 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 28vh 1.5rem 4rem;
+  transition: padding-top 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.page[data-mode='search'] {
+  padding-top: 8vh;
+}
+
+.shell {
+  width: min(100%, 56rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 2.5rem;
+  transition:
+    opacity 350ms ease,
+    transform 350ms ease,
+    max-height 350ms ease,
+    margin 350ms ease;
+}
+
+.page[data-has-query='true'] .hero,
+.page[data-mode='search'] .hero {
+  opacity: 0;
+  transform: translateY(-12px);
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.heroRow {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.heroMark {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.1), transparent);
+  color: var(--color-accent);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.heroMark svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.title {
+  margin: 0;
+  color: #fff;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  line-height: 1;
+  font-weight: 300;
+  letter-spacing: -0.04em;
+}
+
+.gurmukhi {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 1.1rem;
+  font-family: var(--font-gurmukhi), serif;
+}
+
+.searchForm {
+  position: relative;
+  width: 100%;
+  z-index: 5;
+}
+
+.searchFrame {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(20px);
+  transition:
+    background-color 300ms ease,
+    border-color 300ms ease,
+    box-shadow 300ms ease;
+}
+
+.searchFrame:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.searchFrame:focus-within,
+.page[data-has-query='true'] .searchFrame {
+  border-color: rgba(214, 168, 72, 0.38);
+  background: var(--color-panel);
+  box-shadow:
+    var(--shadow-strong),
+    0 0 0 1px rgba(214, 168, 72, 0.2);
+}
+
+.searchIcon {
+  display: grid;
+  place-items: center;
+  padding-left: 1.25rem;
+  padding-right: 0.75rem;
+  color: var(--color-text-subtle);
+  transition: color 300ms ease;
+}
+
+.searchFrame:focus-within .searchIcon,
+.page[data-has-query='true'] .searchIcon {
+  color: var(--color-accent);
+}
+
+.searchIcon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.input {
+  width: 100%;
+  padding: 1.25rem 1rem 1.25rem 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  outline: none;
+  font-size: 1.1rem;
+}
+
+.input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.hint {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  left: 0;
+  width: 100%;
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 0.9rem;
+  text-align: center;
+  pointer-events: none;
+  transition:
+    opacity 250ms ease,
+    transform 250ms ease,
+    max-height 250ms ease,
+    margin 250ms ease;
+}
+
+.page[data-has-query='true'] .hint {
+  opacity: 0;
+  transform: translateY(-8px);
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
+}
+
+.clearButton {
+  margin-right: 1rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.clearButton:hover,
+.clearButton:focus-visible {
+  color: #fff;
+  outline: none;
+}
+
+.shortcutHint {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
+  margin-right: 1rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 0.4rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: #555;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+@media (min-width: 640px) {
+  .shortcutHint {
+    display: inline-flex;
+  }
+}
+
+.content {
+  width: 100%;
+  margin-top: 4rem;
+}
+
+.page[data-has-query='true'] .content {
+  margin-top: 1.75rem;
+}
+
+.quickLinks {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .quickLinks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.page[data-has-query='true'] .quickLinks {
+  display: none;
+}
+
+.quickCard {
+  position: relative;
+  min-height: 6.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  text-align: left;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    background-color 300ms ease,
+    border-color 300ms ease,
+    color 300ms ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+
+.quickCard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.02), transparent);
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+
+.quickCard:hover,
+.quickCard:focus-visible {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: #151515;
+  outline: none;
+}
+
+.quickCard:hover::before,
+.quickCard:focus-visible::before {
+  opacity: 1;
+}
+
+.quickCardTop {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.quickCardTitle {
+  margin: 0;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.quickCard:hover .quickCardTitle,
+.quickCard:focus-visible .quickCardTitle {
+  color: var(--color-accent);
+}
+
+.quickCardDescription {
+  margin: 0.35rem 0 0;
+  color: #777;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.quickCardIcon {
+  flex: none;
+  color: #555;
+  transition: color 300ms ease;
+}
+
+.quickCard:hover .quickCardIcon,
+.quickCard:focus-visible .quickCardIcon {
+  color: rgba(214, 168, 72, 0.75);
+}
+
+.quickCardIcon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.quickCardGhost {
+  min-height: 3.4rem;
+  grid-column: 1 / -1;
+  border-color: rgba(255, 255, 255, 0.02);
+  background: transparent;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quickCardGhostLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-subtle);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.quickCardGhost:hover .quickCardGhostLabel,
+.quickCardGhost:focus-visible .quickCardGhostLabel {
+  color: #fff;
+}
+
+.resultsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.resultsCount {
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.resultsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resultCard {
+  display: block;
+  width: 100%;
+  padding: 1.4rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 300ms ease,
+    background-color 300ms ease,
+    transform 300ms ease;
+}
+
+.resultCard:hover,
+.resultCard:focus-visible {
+  border-color: rgba(255, 255, 255, 0.06);
+  background: #121212;
+  outline: none;
+}
+
+.resultCardTitle {
+  margin: 0;
+  color: var(--color-text);
+  font-size: clamp(1.35rem, 3.5vw, 1.85rem);
+  line-height: 1.6;
+  font-family: var(--font-gurmukhi), serif;
+}
+
+.resultCardMeta {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.resultCardRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 0.85rem;
+}
+
+.resultCardLabel {
+  color: #9a9a9a;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.resultCardGloss {
+  color: #cfcfcf;
+  font-size: 0.98rem;
+  font-style: italic;
+}
+
+.resultCardFooter {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
+  color: var(--color-text-subtle);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 168, 72, 0.2);
+  background: rgba(214, 168, 72, 0.08);
+  color: #e8c96f;
+}
+
+.resultCardMarker {
+  width: 0.36rem;
+  height: 0.36rem;
+  border-radius: 999px;
+  background: rgba(214, 168, 72, 0.5);
+}
+
+.resultsFooter {
+  padding: 2.5rem 0 0.5rem;
+  text-align: center;
+  color: #555;
+  font-size: 0.88rem;
+}
+
+.stateMessage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 16rem;
+  color: var(--color-text-subtle);
+}
+
+.stateMessageCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.stateMessageIcon {
+  margin-bottom: 0.3rem;
+}
+
+.spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--color-text-subtle);
+  animation: spin 1s linear infinite;
+}
+
+.spinner svg {
+  width: 100%;
+  height: 100%;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 639px) {
+  .page {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .page[data-mode='home'] {
+    padding-top: 20vh;
+  }
+}

--- a/apps/web/src/components/search/search-experience.tsx
+++ b/apps/web/src/components/search/search-experience.tsx
@@ -1,0 +1,326 @@
+'use client'
+
+import { useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { createApiClient, type PangtiSearchItem, type WorkSummary } from '@giaan-khand/sdk'
+
+import { buildSearchHref, buildWorkHref } from '@/lib/routes'
+import {
+  buildResultMeta,
+  formatCount,
+  getResultTitle,
+  getStructureTitle,
+  getWorkDescription,
+  getWorkTitle,
+} from '@/lib/format'
+import { getSearchViewState } from '@/lib/search-state'
+
+import styles from './search-experience.module.css'
+
+type SearchExperienceProps = {
+  mode: 'home' | 'search'
+  featuredWorks: WorkSummary[]
+  initialQuery: string
+  initialResults?: PangtiSearchItem[]
+}
+
+const client = createApiClient()
+
+const searchIcon = (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M10.5 4.5a6 6 0 104.03 10.45l4.26 4.27 1.41-1.42-4.26-4.26A6 6 0 0010.5 4.5Zm0 2a4 4 0 110 8 4 4 0 010-8Z"
+    />
+  </svg>
+)
+
+const cardIcon = (
+  <svg viewBox="0 0 20 20" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M5.83 4.58c0-.46.38-.83.84-.83h4.08c.77 0 1.48.28 2.04.76.55-.48 1.26-.76 2.03-.76h.01c.46 0 .83.37.83.83v9.17a.83.83 0 0 1-1.24.72 3.37 3.37 0 0 0-1.69-.47h-.28c-.72 0-1.4.24-1.95.68a.83.83 0 0 1-1.04 0 3.1 3.1 0 0 0-1.95-.68h-.28c-.59 0-1.17.16-1.69.47a.83.83 0 0 1-1.24-.72V4.58Zm1.67.83v7.24c.28-.05.56-.08.84-.08h.28c.59 0 1.16.1 1.71.31V5.42H7.5Zm4.5 7.46c.54-.2 1.11-.31 1.7-.31h.29c.28 0 .56.03.84.08V5.42H13.7c-.63 0-1.24.24-1.7.67v6.78Z"
+    />
+  </svg>
+)
+
+const chevronRightIcon = (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="m9.29 6.71 1.42-1.42L17.41 12l-6.7 6.71-1.42-1.42L14.59 12 9.29 6.71Z" />
+  </svg>
+)
+
+const loadingSpinner = (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3"
+    />
+  </svg>
+)
+
+export function SearchExperience({
+  featuredWorks,
+  initialQuery,
+  initialResults = [],
+  mode,
+}: SearchExperienceProps) {
+  const router = useRouter()
+  const [query, setQuery] = useState(initialQuery)
+  const deferredQuery = useDeferredValue(query)
+  const [results, setResults] = useState<PangtiSearchItem[]>(initialResults)
+  const [total, setTotal] = useState(initialResults.length)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const searchTimer = useRef<number | null>(null)
+  const requestId = useRef(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const didMount = useRef(false)
+
+  const hasQuery = query.trim().length > 0
+
+  useEffect(() => {
+    if (searchTimer.current) {
+      window.clearTimeout(searchTimer.current)
+    }
+
+    if (!didMount.current) {
+      didMount.current = true
+      return
+    }
+
+    const nextHref = buildSearchHref(query)
+    searchTimer.current = window.setTimeout(() => {
+      startTransition(() => {
+        router.replace(nextHref)
+      })
+    }, 180)
+
+    return () => {
+      if (searchTimer.current) {
+        window.clearTimeout(searchTimer.current)
+      }
+      searchTimer.current = null
+    }
+  }, [query, router, startTransition])
+
+  useEffect(() => {
+    const trimmedQuery = deferredQuery.trim()
+    const currentRequest = ++requestId.current
+
+    if (!trimmedQuery) {
+      setResults([])
+      setTotal(0)
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    client
+      .searchPangtis({ q: trimmedQuery, limit: 24 })
+      .then((response) => {
+        if (currentRequest !== requestId.current) {
+          return
+        }
+
+        setResults(response.items)
+        setTotal(response.queryMeta.total)
+        setIsLoading(false)
+      })
+      .catch((cause: unknown) => {
+        if (currentRequest !== requestId.current) {
+          return
+        }
+
+        setResults([])
+        setTotal(0)
+        setIsLoading(false)
+        setError(cause instanceof Error ? cause.message : 'Search request failed')
+      })
+  }, [deferredQuery])
+
+  const quickLinks = useMemo(() => featuredWorks.slice(0, 4), [featuredWorks])
+  const viewState = getSearchViewState({
+    query,
+    isLoading,
+    isPending,
+    error,
+    resultCount: results.length,
+  })
+
+  return (
+    <main
+      className={styles.page}
+      data-mode={mode}
+      data-has-query={hasQuery ? 'true' : 'false'}
+      aria-labelledby="page-title"
+    >
+      <section className={styles.shell}>
+        <div className={styles.hero}>
+          <div className={styles.heroRow}>
+            <div className={styles.heroMark} aria-hidden="true">
+              {cardIcon}
+            </div>
+            <h1 className={styles.title} id="page-title">
+              Giaan Khand
+            </h1>
+          </div>
+          <p className={styles.gurmukhi}>ਗਿਆਨ ਖੰਡ ਕਾ ਆਖਹੁ ਕਰਮੁ ॥</p>
+        </div>
+
+        <form
+          className={styles.searchForm}
+          role="search"
+          onSubmit={(event) => {
+            event.preventDefault()
+            startTransition(() => {
+              router.push(buildSearchHref(query))
+            })
+          }}
+        >
+          <div className={styles.searchFrame}>
+            <span className={styles.searchIcon} aria-hidden="true">
+              {searchIcon}
+            </span>
+              <input
+                ref={inputRef}
+                className={styles.input}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search by first letter..."
+              autoComplete="off"
+              spellCheck={false}
+              aria-label="Search granths by pangti initials"
+            />
+            {hasQuery ? (
+              <button
+                className={styles.clearButton}
+                type="button"
+                onClick={() => {
+                  setQuery('')
+                  inputRef.current?.focus()
+                }}
+                aria-label="Clear search"
+              >
+                Clear
+              </button>
+            ) : (
+              <span className={styles.shortcutHint} aria-hidden="true">
+                /
+              </span>
+            )}
+          </div>
+          <p className={styles.hint}>Type the first letter of each word to search Gurbani</p>
+        </form>
+
+        <section className={styles.content}>
+          {viewState.kind === 'browse' ? (
+            <div className={styles.quickLinks} aria-label="Featured granths">
+              {quickLinks.map((work) => (
+                <button
+                  key={work.slug}
+                  className={styles.quickCard}
+                  type="button"
+                  onClick={() => {
+                    startTransition(() => {
+                      router.push(buildWorkHref(work.slug, query))
+                    })
+                  }}
+                >
+                  <div className={styles.quickCardTop}>
+                    <div>
+                      <h2 className={styles.quickCardTitle}>{getWorkTitle(work)}</h2>
+                      <p className={styles.quickCardDescription}>{getWorkDescription(work)}</p>
+                    </div>
+                    <span className={styles.quickCardIcon} aria-hidden="true">
+                      {cardIcon}
+                    </span>
+                  </div>
+                </button>
+              ))}
+
+              <button
+                className={`${styles.quickCard} ${styles.quickCardGhost}`}
+                type="button"
+                onClick={() => {
+                  inputRef.current?.focus()
+                }}
+              >
+                <span className={styles.quickCardGhostLabel}>
+                  View all Granths
+                  <span aria-hidden="true">{chevronRightIcon}</span>
+                </span>
+              </button>
+            </div>
+          ) : (
+            <div>
+              <div className={styles.resultsHeader}>
+                <p className={styles.resultsCount}>{formatCount(total, 'Result', 'Results')}</p>
+              </div>
+
+              {viewState.kind === 'loading' ? (
+                <div className={styles.stateMessage}>
+                  <div className={styles.stateMessageCopy}>
+                    <span className={styles.stateMessageIcon}>
+                      <span className={styles.spinner}>{loadingSpinner}</span>
+                    </span>
+                    <strong>Loading pangti results...</strong>
+                  </div>
+                </div>
+              ) : viewState.kind === 'error' ? (
+                <div className={styles.stateMessage}>
+                  <div className={styles.stateMessageCopy}>
+                    <span className={styles.stateMessageIcon}>{searchIcon}</span>
+                    <strong>Search request failed</strong>
+                    <p>{viewState.errorMessage}</p>
+                  </div>
+                </div>
+              ) : viewState.kind === 'empty' ? (
+                <div className={styles.stateMessage}>
+                  <div className={styles.stateMessageCopy}>
+                    <span className={styles.stateMessageIcon}>{searchIcon}</span>
+                    <strong>No results found</strong>
+                    <p>Try adjusting your initials query</p>
+                  </div>
+                </div>
+              ) : (
+                <div className={styles.resultsList}>
+                  {results.map((item) => (
+                    <button
+                      key={item.passageId}
+                      className={styles.resultCard}
+                      type="button"
+                      onClick={() => {
+                        startTransition(() => {
+                          router.push(buildWorkHref(item.workSlug, query))
+                        })
+                      }}
+                    >
+                      <p className={styles.resultCardTitle}>{item.originalText}</p>
+                      <div className={styles.resultCardMeta}>
+                        <div className={styles.resultCardRow}>
+                          <span className={styles.resultCardLabel}>{getResultTitle(item)}</span>
+                          <span className={styles.resultCardGloss}>{getStructureTitle(item)}</span>
+                        </div>
+                        <div className={styles.resultCardFooter}>
+                          <span className={styles.resultCardMarker} aria-hidden="true" />
+                          <span>{buildResultMeta(item)}</span>
+                          <span className={styles.badge}>{item.locatorLabel}</span>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                  <div className={styles.resultsFooter}>End of results</div>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+      </section>
+    </main>
+  )
+}

--- a/apps/web/src/components/work/work-detail.module.css
+++ b/apps/web/src/components/work/work-detail.module.css
@@ -1,0 +1,159 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 8vh 1.5rem 4rem;
+}
+
+.shell {
+  width: min(100%, 56rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.backButton {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--color-text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition:
+    background-color 200ms ease,
+    color 200ms ease;
+}
+
+.backButton:hover,
+.backButton:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  outline: none;
+}
+
+.backButton svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 0.9rem;
+}
+
+.title {
+  margin: 0;
+  color: #fff;
+  font-size: clamp(1.4rem, 3vw, 1.75rem);
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  color: #777;
+  font-size: 0.88rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.sectionCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  background: #121212;
+  transition:
+    background-color 300ms ease,
+    border-color 300ms ease;
+}
+
+.sectionCard:hover {
+  background: var(--color-panel-strong);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.sectionCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.sectionCard:hover .sectionTitle {
+  color: var(--color-accent);
+}
+
+.sectionMeta {
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sectionChevron {
+  flex: none;
+  color: #444;
+  transition: color 300ms ease;
+}
+
+.sectionCard:hover .sectionChevron {
+  color: rgba(214, 168, 72, 0.75);
+}
+
+.sectionChevron svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5rem 1rem;
+}
+
+.emptyCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+  color: var(--color-text-subtle);
+}

--- a/apps/web/src/components/work/work-detail.tsx
+++ b/apps/web/src/components/work/work-detail.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+
+import type { StructureNodeSummary, WorkSummary } from '@giaan-khand/sdk'
+
+import { buildSearchHref } from '@/lib/routes'
+import { buildWorkSubtitle, getWorkTitle, humanizeLabel } from '@/lib/format'
+
+import styles from './work-detail.module.css'
+
+const backIcon = (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M14.7 5.29 8 12l6.7 6.71-1.4 1.41L5.17 12l8.13-8.12 1.4 1.41Z" />
+  </svg>
+)
+
+const chevronRightIcon = (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="m9.29 6.71 1.42-1.42L17.41 12l-6.7 6.71-1.42-1.42L14.59 12 9.29 6.71Z" />
+  </svg>
+)
+
+export type WorkDetailProps = {
+  work: WorkSummary
+  sections: StructureNodeSummary[]
+  searchQuery: string
+}
+
+export function WorkDetail({ work, sections, searchQuery }: WorkDetailProps) {
+  const backHref = searchQuery.trim() ? buildSearchHref(searchQuery) : '/'
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.shell}>
+        <div className={styles.topbar}>
+          <Link className={styles.backButton} href={backHref} aria-label="Back to search">
+            {backIcon}
+          </Link>
+
+          <div className={styles.copy}>
+            <p className={styles.label}>{getWorkTitle(work)}</p>
+            <h1 className={styles.title}>{getWorkTitle(work)}</h1>
+            <p className={styles.subtitle}>{buildWorkSubtitle(work)}</p>
+          </div>
+        </div>
+
+        {sections.length ? (
+          <div className={styles.grid}>
+            {sections.map((section) => {
+              const title = section.title.Latn ?? section.title.Guru ?? humanizeLabel(section.nodeType)
+              const meta =
+                section.translation?.en ??
+                section.description?.en ??
+                humanizeLabel(section.nodeType)
+
+              return (
+                <article className={styles.sectionCard} key={section.id}>
+                  <div className={styles.sectionCopy}>
+                    <p className={styles.sectionTitle}>{title}</p>
+                    <p className={styles.sectionMeta}>{meta}</p>
+                  </div>
+                  <span className={styles.sectionChevron} aria-hidden="true">
+                    {chevronRightIcon}
+                  </span>
+                </article>
+              )
+            })}
+          </div>
+        ) : (
+          <div className={styles.emptyState}>
+            <div className={styles.emptyCopy}>
+              <span aria-hidden="true">⦿</span>
+              <strong>Structure content coming soon</strong>
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/apps/web/src/lib/format.spec.ts
+++ b/apps/web/src/lib/format.spec.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildResultMeta, buildWorkSubtitle, getWorkDescription, getWorkTitle, humanizeLabel } from './format'
+
+test('humanizeLabel cleans slugs and underscores', () => {
+  assert.equal(humanizeLabel('guru_granth-sahib'), 'Guru Granth Sahib')
+})
+
+test('getWorkTitle prefers latin and gurmukhi title fields before slug fallback', () => {
+  assert.equal(
+    getWorkTitle({
+      id: 'work-1',
+      slug: 'guru-granth-sahib',
+      title: { Latn: 'Sri Guru Granth Sahib', Guru: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ' },
+      translation: null,
+      summary: null,
+      classification: 'scripture',
+      textShape: 'verse',
+      featured: false,
+    }),
+    'Sri Guru Granth Sahib',
+  )
+})
+
+test('getWorkDescription and buildWorkSubtitle fall back to readable labels', () => {
+  assert.equal(
+    getWorkDescription({
+      id: 'work-2',
+      slug: 'varan',
+      title: { Guru: 'ਵਾਰਾਂ' },
+      translation: null,
+      summary: null,
+      classification: 'collection',
+      textShape: 'prose',
+      featured: false,
+    }),
+    'Collection',
+  )
+
+  assert.equal(
+    buildWorkSubtitle({
+      id: 'work-3',
+      slug: 'nitnem',
+      title: { Guru: 'ਨਿਤਨੇਮ' },
+      translation: null,
+      summary: null,
+      classification: 'prayer',
+      textShape: 'poem',
+      featured: false,
+    }),
+    'Poem',
+  )
+})
+
+test('buildResultMeta keeps the locator and match details together', () => {
+  assert.equal(
+    buildResultMeta({
+      passageId: 'passage-1',
+      workSlug: 'guru-granth-sahib',
+      workTitle: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+      structureLabel: 'ਜਪੁਜੀ ਸਾਹਿਬ',
+      locatorLabel: 'Page 1',
+      originalText: 'ਇਕ ਓਅੰਕਾਰ',
+      matchedBy: 'latin-initials',
+      matchedInitials: 'ios',
+      score: 99,
+    }),
+    'Page 1 • latin-initials • ios',
+  )
+})

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,33 @@
+import type { PangtiSearchItem, WorkSummary } from '@giaan-khand/sdk'
+
+const titleFromField = (field: Record<string, string> | null | undefined, fallback: string) =>
+  field?.Latn ?? field?.Guru ?? Object.values(field ?? {})[0] ?? fallback
+
+export const humanizeLabel = (value: string) =>
+  value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ')
+
+export const formatCount = (count: number, singular: string, plural: string) =>
+  `${count} ${count === 1 ? singular : plural}`
+
+export const getWorkTitle = (work: WorkSummary) =>
+  titleFromField(work.title, humanizeLabel(work.slug))
+
+export const getWorkDescription = (work: WorkSummary) =>
+  work.translation?.en ?? work.summary?.en ?? humanizeLabel(work.classification)
+
+export const getResultTitle = (item: PangtiSearchItem) => item.workTitle
+
+export const getStructureTitle = (item: PangtiSearchItem) => item.structureLabel
+
+export const buildResultMeta = (item: PangtiSearchItem) => {
+  const matchedInitials = item.matchedInitials || 'none'
+
+  return `${item.locatorLabel} • ${item.matchedBy} • ${matchedInitials}`
+}
+
+export const buildWorkSubtitle = (work: WorkSummary) =>
+  work.summary?.en ?? humanizeLabel(work.textShape)

--- a/apps/web/src/lib/routes.spec.ts
+++ b/apps/web/src/lib/routes.spec.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildSearchHref, buildWorkHref } from './routes'
+
+test('buildSearchHref omits empty queries', () => {
+  assert.equal(buildSearchHref('   '), '/')
+  assert.equal(buildSearchHref('ਇਕ'), '/search?q=%E0%A8%87%E0%A8%95')
+  assert.equal(buildSearchHref('  ਇਕ ਓਅੰਕਾਰ  '), '/search?q=%E0%A8%87%E0%A8%95%20%E0%A8%93%E0%A8%85%E0%A9%B0%E0%A8%95%E0%A8%BE%E0%A8%B0')
+})
+
+test('buildWorkHref preserves query context when provided', () => {
+  assert.equal(buildWorkHref('guru-granth-sahib'), '/works/guru-granth-sahib')
+  assert.equal(buildWorkHref('guru/granth sahib', '   '), '/works/guru%2Fgranth%20sahib')
+  assert.equal(
+    buildWorkHref('guru-granth-sahib', 'ਇਕ ਓਅੰਕਾਰ'),
+    '/works/guru-granth-sahib?q=%E0%A8%87%E0%A8%95%20%E0%A8%93%E0%A8%85%E0%A9%B0%E0%A8%95%E0%A8%BE%E0%A8%B0',
+  )
+})

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -1,0 +1,9 @@
+import type { Route } from 'next'
+
+export const buildSearchHref = (query: string): Route =>
+  query.trim() ? (`/search?q=${encodeURIComponent(query.trim())}` as Route) : '/'
+
+export const buildWorkHref = (slug: string, query?: string): Route => {
+  const params = query?.trim() ? `?q=${encodeURIComponent(query.trim())}` : ''
+  return `/works/${encodeURIComponent(slug)}${params}` as Route
+}

--- a/apps/web/src/lib/search-state.spec.ts
+++ b/apps/web/src/lib/search-state.spec.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getSearchViewState } from './search-state'
+
+test('getSearchViewState returns browse state before a query is entered', () => {
+  assert.deepEqual(
+    getSearchViewState({
+      query: '   ',
+      isLoading: false,
+      isPending: false,
+      error: null,
+      resultCount: 0,
+    }),
+    {
+      kind: 'browse',
+      hasQuery: false,
+    },
+  )
+})
+
+test('getSearchViewState prioritizes loading and error states before empty results', () => {
+  assert.deepEqual(
+    getSearchViewState({
+      query: 'ਇਕ',
+      isLoading: true,
+      isPending: false,
+      error: 'timeout',
+      resultCount: 0,
+    }),
+    {
+      kind: 'loading',
+      hasQuery: true,
+    },
+  )
+
+  assert.deepEqual(
+    getSearchViewState({
+      query: 'ਇਕ',
+      isLoading: false,
+      isPending: false,
+      error: 'timeout',
+      resultCount: 0,
+    }),
+    {
+      kind: 'error',
+      hasQuery: true,
+      errorMessage: 'timeout',
+    },
+  )
+})
+
+test('getSearchViewState distinguishes empty and populated result states', () => {
+  assert.deepEqual(
+    getSearchViewState({
+      query: 'ਇਕ',
+      isLoading: false,
+      isPending: false,
+      error: null,
+      resultCount: 0,
+    }),
+    {
+      kind: 'empty',
+      hasQuery: true,
+    },
+  )
+
+  assert.deepEqual(
+    getSearchViewState({
+      query: 'ਇਕ',
+      isLoading: false,
+      isPending: false,
+      error: null,
+      resultCount: 2,
+    }),
+    {
+      kind: 'results',
+      hasQuery: true,
+    },
+  )
+})

--- a/apps/web/src/lib/search-state.ts
+++ b/apps/web/src/lib/search-state.ts
@@ -1,0 +1,64 @@
+export type SearchViewState =
+  | {
+      kind: 'browse'
+      hasQuery: false
+    }
+  | {
+      kind: 'loading'
+      hasQuery: true
+    }
+  | {
+      kind: 'error'
+      hasQuery: true
+      errorMessage: string
+    }
+  | {
+      kind: 'empty'
+      hasQuery: true
+    }
+  | {
+      kind: 'results'
+      hasQuery: true
+    }
+
+export const getSearchViewState = (input: {
+  query: string
+  isLoading: boolean
+  isPending: boolean
+  error: string | null
+  resultCount: number
+}): SearchViewState => {
+  if (!input.query.trim()) {
+    return {
+      kind: 'browse',
+      hasQuery: false,
+    }
+  }
+
+  if (input.isLoading || input.isPending) {
+    return {
+      kind: 'loading',
+      hasQuery: true,
+    }
+  }
+
+  if (input.error) {
+    return {
+      kind: 'error',
+      hasQuery: true,
+      errorMessage: input.error,
+    }
+  }
+
+  if (input.resultCount === 0) {
+    return {
+      kind: 'empty',
+      hasQuery: true,
+    }
+  }
+
+  return {
+    kind: 'results',
+    hasQuery: true,
+  }
+}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,19 @@
+:root {
+  --color-bg: #090909;
+  --color-panel: #141414;
+  --color-panel-strong: #171717;
+  --color-surface: rgba(255, 255, 255, 0.03);
+  --color-surface-strong: rgba(255, 255, 255, 0.05);
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-soft: rgba(255, 255, 255, 0.04);
+  --color-text: #f3f3f2;
+  --color-text-muted: #8a8a8a;
+  --color-text-subtle: #666666;
+  --color-accent: #d6a848;
+  --shadow-soft: 0 4px 16px rgba(0, 0, 0, 0.28);
+  --shadow-strong: 0 12px 42px rgba(0, 0, 0, 0.64);
+  --radius-xl: 1.25rem;
+  --radius-lg: 1rem;
+  --radius-md: 0.75rem;
+  --radius-sm: 0.5rem;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/local-product-stack.md
+++ b/docs/local-product-stack.md
@@ -1,0 +1,62 @@
+# Local Product Stack
+
+This runbook starts the new Giaan Khand product stack locally with:
+
+- PostgreSQL on `54329`
+- Typesense on `8108`
+- Fastify API on `4100`
+- Next.js web app on `3001`
+
+It assumes:
+
+- `Node 22`
+- `pnpm`
+- Homebrew PostgreSQL tools available locally: `initdb`, `pg_ctl`, `createdb`
+- internet access for the first Typesense download
+
+## One-time install
+
+```bash
+pnpm install
+```
+
+## Start local services
+
+```bash
+./scripts/start-local-postgres.sh
+./scripts/start-local-typesense.sh
+```
+
+## Load the archive into the product stack
+
+This uses the built archive SQLite at `dist/archive/archive.sqlite`.
+
+```bash
+./scripts/load-product-data.sh
+```
+
+## Start the apps
+
+```bash
+./scripts/start-product-apps.sh
+```
+
+Then open:
+
+- Web: [http://localhost:3001](http://localhost:3001)
+- API: [http://localhost:4100](http://localhost:4100)
+- OpenAPI: [http://localhost:4100/openapi.json](http://localhost:4100/openapi.json)
+
+## Useful checks
+
+```bash
+curl http://127.0.0.1:4100/health
+curl 'http://127.0.0.1:4100/v1/search/pangtis?q=dkg&limit=1'
+curl http://127.0.0.1:8108/health
+```
+
+## Notes
+
+- The API uses `4100` in this runbook to avoid a common collision with other local services on `4000`.
+- `scripts/load-product-data.sh` is idempotent at the row level because the importer upserts into the Postgres read model.
+- Typesense data and the temporary Postgres cluster are stored under `.tmp/`.

--- a/docs/plans/giaan-khand-search-port-plan.md
+++ b/docs/plans/giaan-khand-search-port-plan.md
@@ -1,0 +1,68 @@
+# Giaan Khand Search Port Plan
+
+This is the approved implementation plan used for the search-first port to the product stack.
+
+## Summary
+
+- Create a new `pnpm` workspace around the current repo and introduce `apps/web` for the frontend, `apps/api` for the public API, `packages/contracts` for shared `Zod` schemas/OpenAPI, `packages/sdk` for the generated typed client, and `packages/search-core` for query normalization and initials mapping.
+- Treat the current static UI in `app/public` as the visual and interaction reference only. Rebuild it as React + TypeScript components in `Next.js` App Router. Do not keep the HTML/CSS/JS app as the product surface.
+- Ship a search-first v1: homepage, global pangti search across all granths, search results with granth/location context, and granth detail pages. Do not include the full reader in this first cut.
+- Move API reads to PostgreSQL now. Keep the existing archive SQLite build pipeline as the source ingest input, and add an importer that materializes the product read model into Postgres plus a derived Typesense search index.
+- Support two input modes in v1: direct Gurmukhi queries and Latin initials mapped to Gurmukhi initials. Do not implement full Latin phonetic transliteration search in this cut.
+
+## Implementation Changes
+
+- Workspace and runtime:
+  - Add `pnpm-workspace.yaml` and convert new app/API work to `Node 22 + pnpm`.
+  - Keep existing Bun/archive tooling untouched and isolated from the new app/API runtime.
+  - Use plain React components plus CSS Modules and one shared global tokens stylesheet for the web app. Do not introduce Tailwind for this port.
+- Web app:
+  - Build `apps/web` with Next.js App Router.
+  - Port the current search-first UI into React components: hero/search shell, quick links, search results list, empty/loading states, and granth detail surface.
+  - Use shareable URLs: `/` for the home/search shell, `/search?q=...` for results, and `/works/[slug]` for granth detail pages with optional query params to preserve search context.
+  - Keep public pages SSR-friendly; server-render the shell and hydrate the interactive search UI client-side.
+- API and contracts:
+  - Build `apps/api` with Fastify as the only shared/public JSON API.
+  - Define request/response contracts in `packages/contracts` and generate OpenAPI plus a typed SDK in `packages/sdk`.
+  - Keep search endpoints out of Next route handlers; the web app must consume the Fastify API through the generated client.
+- Postgres read model and import:
+  - Add a product read model in Postgres for `works`, `structure_nodes`, `passages`, and `passage_texts`, limited to the fields needed for search, granth pages, and result context.
+  - Add an idempotent import command that reads from the built archive SQLite database and upserts the Postgres read model.
+  - Store enough lineage in Postgres to preserve stable IDs/slugs, work relationships, structure hierarchy, page/unit metadata, and the original Gurmukhi body text.
+- Search engine and normalization:
+  - Use Typesense as the v1 search engine.
+  - Add an indexing command that reads from Postgres and writes a `pangtis` index containing at least: passage ID, work slug/title, structure node slug/title, original Gurmukhi text, normalized Gurmukhi text, extracted initials sequence, Latin-initial lookup keys, page or locator metadata, and ranking fields.
+  - Put all query parsing and initials logic in `packages/search-core`.
+  - Implement v1 normalization rules explicitly:
+    - Normalize Gurmukhi punctuation and spacing before initials extraction.
+    - Extract initials from the original Gurmukhi pangti by word, skipping punctuation-only tokens.
+    - Accept direct Gurmukhi query text as-is after normalization.
+    - Accept Latin input as initials only, map each Latin key to one or more allowed Gurmukhi initials, and search against the precomputed initials field.
+    - Do not attempt full phonetic transliteration or full Latin text matching in v1.
+
+## Public Interfaces
+
+- `GET /v1/search/pangtis?q=...&work=...&cursor=...&limit=...` returns `{ items, nextCursor, queryMeta }`.
+- `PangtiSearchItem` includes `passageId`, `workSlug`, `workTitle`, `structureLabel`, `locatorLabel`, `originalText`, `matchedBy`, `matchedInitials`, and `score`.
+- `GET /v1/works` returns curated or searchable work summaries for homepage quick links and browse surfaces.
+- `GET /v1/works/:slug` returns work metadata plus top-level structure summaries used by the granth detail page.
+- `GET /v1/passages/:id` returns one passage with its immediate context metadata for result expansion and deep-linking from search results.
+- `packages/contracts` defines the exact query/response schemas for these endpoints and is the single source of truth for OpenAPI and SDK generation.
+
+## Test Plan
+
+- Unit-test `packages/search-core` for Gurmukhi normalization, initials extraction, Latin-to-Gurmukhi initials mapping, punctuation handling, and query-mode detection.
+- Add fixture tests proving that a direct Gurmukhi query and its Latin-initial equivalent hit the same pangti set for representative passages.
+- Add importer tests proving stable IDs/slugs and hierarchy are preserved from SQLite into Postgres.
+- Add indexer tests proving indexed documents contain the expected search fields and ranking inputs.
+- Add Fastify integration tests for all v1 endpoints, including pagination, work filtering, empty results, unknown work slugs, and passage lookup failures.
+- Add web tests for homepage rendering, search-state URL sync, result rendering, empty/loading states, and navigation into `/works/[slug]`.
+- Add at least one end-to-end flow covering: load homepage, search by Latin initials, view global results across multiple granths, open a granth detail page, and return to the same search context.
+
+## Assumptions and Defaults
+
+- `Typesense` is the chosen search engine for v1.
+- The existing archive SQLite build remains the ingest source, but the new API runtime reads from Postgres, not SQLite.
+- v1 supports direct Gurmukhi search and Latin initials mapped to Gurmukhi initials only; full phonetic Latin transliteration search is explicitly out of scope.
+- v1 frontend scope is search/discovery only: no full reader, annotation, or authenticated flows.
+- The current static app remains only as a temporary reference during migration and is removed from the critical product path once the new web/API stack reaches feature parity.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "type": "module",
   "imports": {
+    "#archive/*": "./archive/src/*.ts",
     "#~/*": "./src/*.ts",
     "#collections-types/*": "./collections/$schemas/.types/*.d.ts"
   },
@@ -44,7 +45,19 @@
     "predatabase:build": "bun run collections:generate-types",
     "database:build": "bun scripts/build-database.ts",
     "database:build-slices": "bun scripts/create-db-slices.ts",
-    "database:view": "drizzle-kit studio"
+    "database:view": "drizzle-kit studio",
+    "dev:api": "pnpm --filter @giaan-khand/api dev",
+    "dev:web": "pnpm --filter @giaan-khand/web dev",
+    "test:api": "pnpm --filter @giaan-khand/api test",
+    "test:search-core": "pnpm --filter @giaan-khand/search-core test",
+    "openapi:write": "pnpm --filter @giaan-khand/api openapi:write",
+    "product:init": "pnpm --filter @giaan-khand/api db:init",
+    "product:import": "pnpm --filter @giaan-khand/api import:archive",
+    "search:index": "pnpm --filter @giaan-khand/api index:pangtis",
+    "stack:postgres": "bash ./scripts/start-local-postgres.sh",
+    "stack:typesense": "bash ./scripts/start-local-typesense.sh",
+    "stack:load": "bash ./scripts/load-product-data.sh",
+    "stack:start": "bash ./scripts/start-product-apps.sh"
   },
   "dependencies": {
     "drizzle-orm": "^1.0.0-beta.1-8aabc28"
@@ -57,6 +70,7 @@
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-angular": "^19.8.0",
     "@types/bun": "latest",
+    "@types/node": "^22.13.10",
     "ajv": "^8.17.1",
     "consola": "^3.4.2",
     "dedent": "^1.5.3",
@@ -64,6 +78,8 @@
     "husky": "^9.1.7",
     "json-schema-to-typescript": "^15.0.4",
     "smol-toml": "^1.3.1",
+    "tsx": "^4.19.3",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6"
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@giaan-khand/contracts",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.2.0",
+    "zod": "^3.24.2"
+  }
+}
+

--- a/packages/contracts/src/contracts.spec.ts
+++ b/packages/contracts/src/contracts.spec.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { pangtiSearchQuerySchema, worksResponseSchema } from './contracts'
+
+test('pangtiSearchQuerySchema accepts a valid query payload', () => {
+  const parsed = pangtiSearchQuerySchema.parse({
+    q: 'ਦਕਗ',
+    limit: '10',
+  })
+
+  assert.equal(parsed.limit, 10)
+})
+
+test('worksResponseSchema requires an items array', () => {
+  const parsed = worksResponseSchema.parse({
+    items: [],
+  })
+
+  assert.deepEqual(parsed.items, [])
+})
+

--- a/packages/contracts/src/contracts.ts
+++ b/packages/contracts/src/contracts.ts
@@ -1,0 +1,215 @@
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV3,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi'
+import { z } from 'zod'
+
+extendZodWithOpenApi(z)
+
+const scriptFieldSchema = z.record(z.string(), z.string())
+const languageFieldSchema = z.record(z.string(), z.string())
+
+export const workSummarySchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: scriptFieldSchema,
+  translation: languageFieldSchema.nullable(),
+  summary: languageFieldSchema.nullable().optional(),
+  classification: z.string(),
+  textShape: z.string(),
+  featured: z.boolean().default(false),
+})
+
+export const worksResponseSchema = z.object({
+  items: z.array(workSummarySchema),
+})
+
+export const structureNodeSummarySchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  nodeType: z.string(),
+  title: scriptFieldSchema,
+  translation: languageFieldSchema.nullable(),
+  description: languageFieldSchema.nullable(),
+  position: z.number().int(),
+})
+
+export const workDetailResponseSchema = z.object({
+  work: workSummarySchema,
+  sections: z.array(structureNodeSummarySchema),
+})
+
+export const passageDetailResponseSchema = z.object({
+  passageId: z.string(),
+  workSlug: z.string(),
+  workTitle: z.string(),
+  structureLabel: z.string(),
+  locatorLabel: z.string(),
+  originalText: z.string(),
+  pageStart: z.number().int().nullable(),
+  pageEnd: z.number().int().nullable(),
+})
+
+export const pangtiSearchItemSchema = z.object({
+  passageId: z.string(),
+  workSlug: z.string(),
+  workTitle: z.string(),
+  structureLabel: z.string(),
+  locatorLabel: z.string(),
+  originalText: z.string(),
+  matchedBy: z.enum(['gurmukhi', 'latin-initials']),
+  matchedInitials: z.string(),
+  score: z.number(),
+})
+
+export const pangtiSearchQuerySchema = z.object({
+  q: z.string().trim().min(1),
+  work: z.string().trim().min(1).optional(),
+  cursor: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(50).default(20).optional(),
+})
+
+export const pangtiSearchResponseSchema = z.object({
+  items: z.array(pangtiSearchItemSchema),
+  nextCursor: z.string().nullable(),
+  queryMeta: z.object({
+    mode: z.enum(['gurmukhi', 'latin-initials']),
+    normalizedQuery: z.string(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive(),
+    total: z.number().int().nonnegative(),
+  }),
+})
+
+export const errorResponseSchema = z.object({
+  error: z.string(),
+})
+
+export type WorkSummary = z.infer<typeof workSummarySchema>
+export type WorksResponse = z.infer<typeof worksResponseSchema>
+export type StructureNodeSummary = z.infer<typeof structureNodeSummarySchema>
+export type WorkDetailResponse = z.infer<typeof workDetailResponseSchema>
+export type PassageDetailResponse = z.infer<typeof passageDetailResponseSchema>
+export type PangtiSearchItem = z.infer<typeof pangtiSearchItemSchema>
+export type PangtiSearchQuery = z.infer<typeof pangtiSearchQuerySchema>
+export type PangtiSearchResponse = z.infer<typeof pangtiSearchResponseSchema>
+export type ErrorResponse = z.infer<typeof errorResponseSchema>
+
+const registry = new OpenAPIRegistry()
+
+registry.register('WorkSummary', workSummarySchema)
+registry.register('WorksResponse', worksResponseSchema)
+registry.register('StructureNodeSummary', structureNodeSummarySchema)
+registry.register('WorkDetailResponse', workDetailResponseSchema)
+registry.register('PassageDetailResponse', passageDetailResponseSchema)
+registry.register('PangtiSearchItem', pangtiSearchItemSchema)
+registry.register('PangtiSearchResponse', pangtiSearchResponseSchema)
+registry.register('ErrorResponse', errorResponseSchema)
+
+registry.registerPath({
+  method: 'get',
+  path: '/v1/works',
+  responses: {
+    200: {
+      description: 'Curated work summaries',
+      content: {
+        'application/json': {
+          schema: worksResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+registry.registerPath({
+  method: 'get',
+  path: '/v1/works/{slug}',
+  request: {
+    params: z.object({
+      slug: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Work detail',
+      content: {
+        'application/json': {
+          schema: workDetailResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Work not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+registry.registerPath({
+  method: 'get',
+  path: '/v1/passages/{id}',
+  request: {
+    params: z.object({
+      id: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Passage detail',
+      content: {
+        'application/json': {
+          schema: passageDetailResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Passage not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+registry.registerPath({
+  method: 'get',
+  path: '/v1/search/pangtis',
+  request: {
+    query: pangtiSearchQuerySchema,
+  },
+  responses: {
+    200: {
+      description: 'Global pangti search results',
+      content: {
+        'application/json': {
+          schema: pangtiSearchResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Validation error',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
+        },
+      },
+    },
+  },
+})
+
+const generator = new OpenApiGeneratorV3(registry.definitions)
+
+export const openApiDocument = generator.generateDocument({
+  openapi: '3.1.0',
+  info: {
+    title: 'Giaan Khand Public API',
+    version: '0.1.0',
+  },
+})

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,22 @@
+export {
+  errorResponseSchema,
+  openApiDocument,
+  pangtiSearchItemSchema,
+  pangtiSearchQuerySchema,
+  pangtiSearchResponseSchema,
+  passageDetailResponseSchema,
+  structureNodeSummarySchema,
+  workDetailResponseSchema,
+  worksResponseSchema,
+  workSummarySchema,
+  type ErrorResponse,
+  type PangtiSearchItem,
+  type PangtiSearchQuery,
+  type PangtiSearchResponse,
+  type PassageDetailResponse,
+  type StructureNodeSummary,
+  type WorkDetailResponse,
+  type WorksResponse,
+  type WorkSummary,
+} from './contracts'
+

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@giaan-khand/sdk",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@giaan-khand/contracts": "workspace:*"
+  }
+}
+

--- a/packages/sdk/src/client.spec.ts
+++ b/packages/sdk/src/client.spec.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createApiClient } from './client'
+
+test('createApiClient parses work list responses', async () => {
+  const client = createApiClient('http://example.test', async () => {
+    return new Response(
+      JSON.stringify({
+        items: [
+          {
+            id: 'work-1',
+            slug: 'guru-granth-sahib',
+            title: {
+              Guru: 'ਗੁਰੂ ਗ੍ਰੰਥ ਸਾਹਿਬ',
+            },
+            translation: null,
+            classification: 'scripture',
+            textShape: 'verse',
+            featured: true,
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    )
+  })
+
+  const response = await client.listWorks()
+
+  assert.equal(response.items[0]?.slug, 'guru-granth-sahib')
+})
+

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,93 @@
+import {
+  pangtiSearchResponseSchema,
+  passageDetailResponseSchema,
+  workDetailResponseSchema,
+  worksResponseSchema,
+  type PangtiSearchQuery,
+  type PangtiSearchResponse,
+  type PassageDetailResponse,
+  type WorkDetailResponse,
+  type WorksResponse,
+} from '@giaan-khand/contracts'
+
+export type ApiClientOptions = {
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+}
+
+const DEFAULT_API_BASE_URL = 'http://localhost:4000'
+
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+export const resolveApiBaseUrl = () =>
+  trimTrailingSlash(
+    process.env.NEXT_PUBLIC_API_BASE_URL ??
+      process.env.API_BASE_URL ??
+      DEFAULT_API_BASE_URL,
+  )
+
+const buildUrl = (path: string, baseUrl: string) => new URL(path, `${baseUrl}/`).toString()
+
+const requestJson = async <T>(
+  path: string,
+  schema: { parse: (value: unknown) => T },
+  options: ApiClientOptions = {},
+) => {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const baseUrl = options.baseUrl ?? resolveApiBaseUrl()
+  const response = await fetchImpl(buildUrl(path, baseUrl), {
+    cache: 'no-store',
+    headers: {
+      accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`Request failed for ${path}: ${response.status}${body ? ` ${body}` : ''}`)
+  }
+
+  return schema.parse(await response.json())
+}
+
+export const createApiClient = (baseUrl?: string, fetchImpl?: typeof fetch) => ({
+  listWorks: (): Promise<WorksResponse> =>
+    requestJson('/v1/works', worksResponseSchema, { baseUrl, fetchImpl }),
+  getWork: (slug: string): Promise<WorkDetailResponse> =>
+    requestJson(`/v1/works/${encodeURIComponent(slug)}`, workDetailResponseSchema, {
+      baseUrl,
+      fetchImpl,
+    }),
+  getPassage: (id: string): Promise<PassageDetailResponse> =>
+    requestJson(`/v1/passages/${encodeURIComponent(id)}`, passageDetailResponseSchema, {
+      baseUrl,
+      fetchImpl,
+    }),
+  searchPangtis: (query: PangtiSearchQuery): Promise<PangtiSearchResponse> => {
+    const params = new URLSearchParams()
+
+    params.set('q', query.q)
+
+    if (query.work) {
+      params.set('work', query.work)
+    }
+
+    if (query.cursor) {
+      params.set('cursor', query.cursor)
+    }
+
+    if (query.limit) {
+      params.set('limit', String(query.limit))
+    }
+
+    return requestJson(
+      `/v1/search/pangtis?${params.toString()}`,
+      pangtiSearchResponseSchema,
+      {
+        baseUrl,
+        fetchImpl,
+      },
+    )
+  },
+})
+

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,13 @@
+export { createApiClient, resolveApiBaseUrl, type ApiClientOptions } from './client'
+export type {
+  ErrorResponse,
+  PangtiSearchItem,
+  PangtiSearchQuery,
+  PangtiSearchResponse,
+  PassageDetailResponse,
+  StructureNodeSummary,
+  WorkDetailResponse,
+  WorksResponse,
+  WorkSummary,
+} from '@giaan-khand/contracts'
+

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/search-core/package.json
+++ b/packages/search-core/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@giaan-khand/search-core",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "tsx --test src/**/*.spec.ts"
+  }
+}
+

--- a/packages/search-core/src/index.ts
+++ b/packages/search-core/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  buildSearchDocumentFields,
+  detectQueryMode,
+  extractGurmukhiInitials,
+  normalizeGurmukhiText,
+  normalizeLatinInitialQuery,
+  toLatinInitials,
+  tokenizeGurmukhiText,
+  type QueryMode,
+} from './pangti'
+

--- a/packages/search-core/src/pangti.spec.ts
+++ b/packages/search-core/src/pangti.spec.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildSearchDocumentFields,
+  detectQueryMode,
+  extractGurmukhiInitials,
+  normalizeGurmukhiText,
+  normalizeLatinInitialQuery,
+  toLatinInitials,
+} from './pangti'
+
+test('normalizeGurmukhiText strips punctuation and collapses spacing', () => {
+  assert.equal(normalizeGurmukhiText(' ਇਕ   ਓਅੰਕਾਰ; ਸਤਿਨਾਮੁ ॥ '), 'ਇਕ ਓਅੰਕਾਰ ਸਤਿਨਾਮੁ')
+})
+
+test('extractGurmukhiInitials returns one initial per token', () => {
+  assert.equal(extractGurmukhiInitials('ਇਕ ਓਅੰਕਾਰ ਸਤਿਨਾਮੁ'), 'ਇਓਸ')
+})
+
+test('toLatinInitials maps gurmukhi initials into canonical latin keys', () => {
+  assert.equal(toLatinInitials('ਦਇਆ ਕਰਹੁ ਗੋਬਿੰਦ'), 'dkg')
+})
+
+test('normalizeLatinInitialQuery canonicalizes alias keys', () => {
+  assert.equal(normalizeLatinInitialQuery('D f w'), 'dpv')
+})
+
+test('detectQueryMode prefers gurmukhi when gurmukhi codepoints are present', () => {
+  assert.equal(detectQueryMode('ਦਇਆ'), 'gurmukhi')
+  assert.equal(detectQueryMode('dkg'), 'latin-initials')
+})
+
+test('buildSearchDocumentFields keeps gurmukhi and latin initials aligned', () => {
+  assert.deepEqual(buildSearchDocumentFields('ਦਇਆ ਕਰਹੁ ਗੋਬਿੰਦ'), {
+    normalizedText: 'ਦਇਆ ਕਰਹੁ ਗੋਬਿੰਦ',
+    gurmukhiInitials: 'ਦਕਗ',
+    latinInitials: 'dkg',
+  })
+})
+

--- a/packages/search-core/src/pangti.ts
+++ b/packages/search-core/src/pangti.ts
@@ -1,0 +1,101 @@
+const GURMUKHI_REGEX = /\p{Script=Gurmukhi}/u
+const TOKEN_REGEX = /[\p{Letter}\p{Number}\p{Mark}]+/gu
+
+const LATIN_ALIAS_MAP: Record<string, string> = {
+  c: 'c',
+  f: 'p',
+  q: 'k',
+  v: 'v',
+  w: 'v',
+  x: 'k',
+  z: 'j',
+}
+
+const GURMUKHI_TO_LATIN: Record<string, string> = {
+  'ਅ': 'a',
+  'ਆ': 'a',
+  'ਇ': 'i',
+  'ਈ': 'i',
+  'ਉ': 'u',
+  'ਊ': 'u',
+  'ਏ': 'e',
+  'ਐ': 'e',
+  'ਓ': 'o',
+  'ਔ': 'o',
+  'ੳ': 'a',
+  'ਅ਼': 'a',
+  'ਸ': 's',
+  'ਸ਼': 's',
+  '਷': 's',
+  'ਹ': 'h',
+  'ਕ': 'k',
+  'ਖ': 'k',
+  'ਖ਼': 'k',
+  'ਗ': 'g',
+  'ਘ': 'g',
+  'ਙ': 'n',
+  'ਚ': 'c',
+  'ਛ': 'c',
+  'ਜ': 'j',
+  'ਝ': 'j',
+  'ਜ਼': 'j',
+  'ਞ': 'n',
+  'ਟ': 't',
+  'ਠ': 't',
+  'ਡ': 'd',
+  'ਢ': 'd',
+  'ਣ': 'n',
+  'ਤ': 't',
+  'ਥ': 't',
+  'ਦ': 'd',
+  'ਧ': 'd',
+  'ਨ': 'n',
+  'ਪ': 'p',
+  'ਫ': 'p',
+  'ਫ਼': 'p',
+  'ਬ': 'b',
+  'ਭ': 'b',
+  'ਮ': 'm',
+  'ਯ': 'y',
+  'ਰ': 'r',
+  'ੜ': 'r',
+  'ਲ': 'l',
+  'ਲ਼': 'l',
+  'ਵ': 'v',
+}
+
+export type QueryMode = 'gurmukhi' | 'latin-initials'
+
+export const tokenizeGurmukhiText = (value: string) => value.match(TOKEN_REGEX) ?? []
+
+export const normalizeGurmukhiText = (value: string) =>
+  tokenizeGurmukhiText(value.trim().normalize('NFC')).join(' ')
+
+export const extractGurmukhiInitials = (value: string) =>
+  tokenizeGurmukhiText(value)
+    .map((token) => Array.from(token)[0] ?? '')
+    .filter(Boolean)
+    .join('')
+
+const canonicalizeLatinCharacter = (character: string) =>
+  LATIN_ALIAS_MAP[character.toLowerCase()] ?? character.toLowerCase()
+
+export const normalizeLatinInitialQuery = (value: string) =>
+  Array.from(value.toLowerCase())
+    .filter((character) => /[a-z0-9]/.test(character))
+    .map(canonicalizeLatinCharacter)
+    .join('')
+
+export const toLatinInitials = (value: string) =>
+  Array.from(extractGurmukhiInitials(value))
+    .map((character) => GURMUKHI_TO_LATIN[character] ?? '')
+    .join('')
+
+export const detectQueryMode = (value: string): QueryMode =>
+  GURMUKHI_REGEX.test(value) ? 'gurmukhi' : 'latin-initials'
+
+export const buildSearchDocumentFields = (value: string) => ({
+  normalizedText: normalizeGurmukhiText(value),
+  gurmukhiInitials: extractGurmukhiInitials(value),
+  latinInitials: toLatinInitials(value),
+})

--- a/packages/search-core/tsconfig.json
+++ b/packages/search-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,4120 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@libsql/client':
+        specifier: ^0.15.1
+        version: 0.15.15
+      drizzle-orm:
+        specifier: ^1.0.0-beta.1-8aabc28
+        version: 1.0.0-beta.9-e89174b(@libsql/client@0.15.15)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.20.0)(bun-types@1.3.11)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.0.0-beta.1
+        version: 2.4.10
+      '@commitlint/cli':
+        specifier: ^19.8.0
+        version: 19.8.1(@types/node@22.19.15)(typescript@5.9.3)
+      '@commitlint/config-angular':
+        specifier: ^19.8.0
+        version: 19.8.1
+      '@types/bun':
+        specifier: latest
+        version: 1.3.11
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.19.15
+      ajv:
+        specifier: ^8.17.1
+        version: 8.18.0
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      dedent:
+        specifier: ^1.5.3
+        version: 1.7.2
+      drizzle-kit:
+        specifier: ^1.0.0-beta.1-8aabc28
+        version: 1.0.0-beta.9-e89174b
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      json-schema-to-typescript:
+        specifier: ^15.0.4
+        version: 15.0.4
+      smol-toml:
+        specifier: ^1.3.1
+        version: 1.6.1
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  apps/api:
+    dependencies:
+      '@fastify/cors':
+        specifier: ^11.0.0
+        version: 11.2.0
+      '@fastify/swagger':
+        specifier: ^9.5.1
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.2
+        version: 5.2.5
+      '@giaan-khand/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@giaan-khand/search-core':
+        specifier: workspace:*
+        version: link:../../packages/search-core
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      drizzle-orm:
+        specifier: ^1.0.0-beta.1-8aabc28
+        version: 1.0.0-beta.9-e89174b(@libsql/client@0.15.15)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.20.0)(bun-types@1.3.11)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)
+      fastify:
+        specifier: ^5.2.1
+        version: 5.8.4
+      fastify-type-provider-zod:
+        specifier: ^4.0.2
+        version: 4.0.2(fastify@5.8.4)(zod@3.25.76)
+      pg:
+        specifier: ^8.13.3
+        version: 8.20.0
+      typesense:
+        specifier: ^2.0.0
+        version: 2.1.0(@babel/runtime@7.29.2)
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.19.15
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+
+  apps/web:
+    dependencies:
+      '@giaan-khand/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      next:
+        specifier: ^15.3.0
+        version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.15
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.4
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
+  packages/contracts:
+    dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^7.2.0
+        version: 7.3.4(zod@3.25.76)
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+
+  packages/sdk:
+    dependencies:
+      '@giaan-khand/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+
+  packages/search-core: {}
+
+packages:
+
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
+    engines: {node: '>= 16'}
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
+
+  '@azure-rest/core-client@2.5.1':
+    resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.3.2':
+    resolution: {integrity: sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.23.0':
+    resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-common@2.0.0':
+    resolution: {integrity: sha512-wRLVaroQtOqfg60cxkzUkGKrKMsCP6uYXAOomOIysSMyt1/YM0eUn9LqieAWM8DLcU4+07Fio2YGpPeqUbpP9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/keyvault-keys@4.10.0':
+    resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/msal-browser@5.6.3':
+    resolution: {integrity: sha512-sTjMtUm+bJpENU/1WlRzHEsgEHppZDZ1EtNyaOODg/sQBtMxxJzGB+MOCM+T2Q5Qe1fKBrdxUmjyRxm0r7Ez9w==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.4.1':
+    resolution: {integrity: sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.1.2':
+    resolution: {integrity: sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==}
+    engines: {node: '>=20'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.10':
+    resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.10':
+    resolution: {integrity: sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.10':
+    resolution: {integrity: sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
+    resolution: {integrity: sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.10':
+    resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.10':
+    resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.10':
+    resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.10':
+    resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.10':
+    resolution: {integrity: sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@commitlint/cli@19.8.1':
+    resolution: {integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-angular-type-enum@19.8.1':
+    resolution: {integrity: sha512-JKEINTDQcH5+qSq0Fcp/gzT7SQ3RvY74SNXiMABNTsseocB33TKMzPwDJHZbl/hyRemWEE97Qbxz+ILnJ+9AZQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-angular@19.8.1':
+    resolution: {integrity: sha512-5OAVgqwg6m4iXP2FkrswKZjrgzyQetR5Jkyt5SajlxLfKzZOzdB3hSqVJQdtvF/AxiMwz9Ey5BIXTCfSIrvZGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@19.8.1':
+    resolution: {integrity: sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@19.8.1':
+    resolution: {integrity: sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@19.8.1':
+    resolution: {integrity: sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@19.8.1':
+    resolution: {integrity: sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@19.8.1':
+    resolution: {integrity: sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@19.8.1':
+    resolution: {integrity: sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@19.8.1':
+    resolution: {integrity: sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@19.8.1':
+    resolution: {integrity: sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@19.8.1':
+    resolution: {integrity: sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@19.8.1':
+    resolution: {integrity: sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@19.8.1':
+    resolution: {integrity: sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@19.8.1':
+    resolution: {integrity: sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@19.8.1':
+    resolution: {integrity: sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@19.8.1':
+    resolution: {integrity: sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@19.8.1':
+    resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
+    engines: {node: '>=v18'}
+
+  '@drizzle-team/brocli@0.11.0':
+    resolution: {integrity: sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@11.2.0':
+    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+
+  '@fastify/swagger-ui@5.2.5':
+    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@js-joda/core@5.7.0':
+    resolution: {integrity: sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
+
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
+  '@libsql/client@0.15.15':
+    resolution: {integrity: sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==}
+
+  '@libsql/core@0.15.15':
+    resolution: {integrity: sha512-C88Z6UKl+OyuKKPwz224riz02ih/zHYI3Ho/LAcVOgjsunIRZoBw7fjRfaH9oPMmSNeQfhGklSG2il1URoOIsA==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.7.0':
+    resolution: {integrity: sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==}
+
+  '@libsql/isomorphic-fetch@0.3.1':
+    resolution: {integrity: sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==}
+    engines: {node: '>=18.0.0'}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
+
+  '@next/env@15.5.14':
+    resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
+
+  '@next/swc-darwin-arm64@15.5.14':
+    resolution: {integrity: sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.14':
+    resolution: {integrity: sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.14':
+    resolution: {integrity: sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.5.14':
+    resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.14':
+    resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.5.14':
+    resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@15.5.14':
+    resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.14':
+    resolution: {integrity: sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tediousjs/connection-string@0.5.0':
+    resolution: {integrity: sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ==}
+
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
+  '@types/conventional-commits-parser@5.0.2':
+    resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/mssql@9.1.11':
+    resolution: {integrity: sha512-vcujgrDbDezCxNDO4KY6gjwduLYOKfrexpRUwhoysRvcXZ3+IgZ/PMYFDgh8c3cQIxZ6skAwYo+H6ibMrBWPjQ==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/readable-stream@4.0.23':
+    resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typespec/ts-http-runtime@0.3.4':
+    resolution: {integrity: sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==}
+    engines: {node: '>=20.0.0'}
+
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bl@6.1.6:
+    resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001784:
+    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-angular@7.0.0:
+    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
+    engines: {node: '>=16'}
+
+  conventional-commits-parser@5.0.0:
+    resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cosmiconfig-typescript-loader@6.2.0:
+    resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dargs@8.1.0:
+    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
+    engines: {node: '>=12'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  drizzle-kit@1.0.0-beta.9-e89174b:
+    resolution: {integrity: sha512-Xrw3k8E2CbSZr+kqe3k5W4oxd2fbEyczjKtyGIkAq0x9Wqpa/VtAT6Mkh83sIzqG4OSN7lOoUafsDxSE/AR7RA==}
+    hasBin: true
+
+  drizzle-orm@1.0.0-beta.9-e89174b:
+    resolution: {integrity: sha512-B5KR/qYMZ0JMOurK+0xi1ObpOQcgrjaC9wHUiU2eTJjLemuh2CoQIw6yur68NxZG6Xcd0b9qghUNC/78/bEfbg==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@effect/sql': ^0.48.5
+      '@effect/sql-pg': ^0.49.7
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@sqlitecloud/drivers': '>=1.0.653'
+      '@tidbcloud/serverless': '*'
+      '@tursodatabase/database': '>=0.2.1'
+      '@tursodatabase/database-common': '>=0.2.1'
+      '@tursodatabase/database-wasm': '>=0.2.1'
+      '@types/better-sqlite3': '*'
+      '@types/mssql': ^9.1.4
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=9.3.0'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      mssql: ^11.0.1
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@effect/sql':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sqlitecloud/drivers':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@tursodatabase/database':
+        optional: true
+      '@tursodatabase/database-common':
+        optional: true
+      '@tursodatabase/database-wasm':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify-type-provider-zod@4.0.2:
+    resolution: {integrity: sha512-FDRzSL3ZuoZ+4YDevR1YOinmDKkxOdy3QB9dDR845sK+bQvDroPKhHAXLEAOObDxL7SMA0OZN/A4osrNBTdDTQ==}
+    peerDependencies:
+      fastify: ^5.0.0
+      zod: ^3.14.2
+
+  fastify@5.8.4:
+    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
+
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  git-raw-commits@4.0.0:
+    resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
+    engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-text-path@2.0.0:
+    resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
+    engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
+
+  json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    os: [darwin, linux, win32]
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+
+  lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  meow@12.1.1:
+    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
+    engines: {node: '>=16.10'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mssql@11.0.1:
+    resolution: {integrity: sha512-KlGNsugoT90enKlR8/G36H0kTxPthDhmtNUCwEHvgRza5Cjpjoj+P2X6eMpFUDN7pFrJZsKadL4x990G8RBE1w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  native-duplexpair@1.0.0:
+    resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
+
+  next@15.5.14:
+    resolution: {integrity: sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
+  tedious@18.6.2:
+    resolution: {integrity: sha512-g7jC56o3MzLkE3lHkaFe2ZdOVFBahq5bsB60/M4NYUbocw/MCrS89IOEQUFr+ba6pb8ZHczZ/VqCyYeYq0xBAg==}
+    engines: {node: '>=18'}
+
+  tedious@19.2.1:
+    resolution: {integrity: sha512-pk1Q16Yl62iocuQB+RWbg6rFUFkIyzqOFQ6NfysCltRvQqKwfurgj8v/f2X+CKvDhSL4IJ0cCOfCHDg9PWEEYA==}
+    engines: {node: '>=18.17'}
+
+  text-extensions@2.4.0:
+    resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
+    engines: {node: '>=8'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typesense@2.1.0:
+    resolution: {integrity: sha512-a/IRTL+dRXlpRDU4UodyGj8hl5xBz3nKihVRd/KfSFAfFPGcpdX6lxIgwdXy3O6VLNNiEsN8YwIsPHQPVT0vNw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/runtime': ^7.23.2
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
+
+  '@azure-rest/core-client@2.5.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@typespec/ts-http-runtime': 0.3.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.23.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 5.6.3
+      '@azure/msal-node': 5.1.2
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-common@2.0.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.5.1
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/keyvault-common': 2.0.0
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@5.6.3':
+    dependencies:
+      '@azure/msal-common': 16.4.1
+
+  '@azure/msal-common@16.4.1': {}
+
+  '@azure/msal-node@5.1.2':
+    dependencies:
+      '@azure/msal-common': 16.4.1
+      jsonwebtoken: 9.0.3
+      uuid: 8.3.2
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@biomejs/biome@2.4.10':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.10
+      '@biomejs/cli-darwin-x64': 2.4.10
+      '@biomejs/cli-linux-arm64': 2.4.10
+      '@biomejs/cli-linux-arm64-musl': 2.4.10
+      '@biomejs/cli-linux-x64': 2.4.10
+      '@biomejs/cli-linux-x64-musl': 2.4.10
+      '@biomejs/cli-win32-arm64': 2.4.10
+      '@biomejs/cli-win32-x64': 2.4.10
+
+  '@biomejs/cli-darwin-arm64@2.4.10':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.10':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.10':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.10':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.10':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.10':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.10':
+    optional: true
+
+  '@commitlint/cli@19.8.1(@types/node@22.19.15)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/format': 19.8.1
+      '@commitlint/lint': 19.8.1
+      '@commitlint/load': 19.8.1(@types/node@22.19.15)(typescript@5.9.3)
+      '@commitlint/read': 19.8.1
+      '@commitlint/types': 19.8.1
+      tinyexec: 1.0.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/config-angular-type-enum@19.8.1': {}
+
+  '@commitlint/config-angular@19.8.1':
+    dependencies:
+      '@commitlint/config-angular-type-enum': 19.8.1
+
+  '@commitlint/config-validator@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      ajv: 8.18.0
+
+  '@commitlint/ensure@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  '@commitlint/execute-rule@19.8.1': {}
+
+  '@commitlint/format@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      chalk: 5.6.2
+
+  '@commitlint/is-ignored@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      semver: 7.7.4
+
+  '@commitlint/lint@19.8.1':
+    dependencies:
+      '@commitlint/is-ignored': 19.8.1
+      '@commitlint/parse': 19.8.1
+      '@commitlint/rules': 19.8.1
+      '@commitlint/types': 19.8.1
+
+  '@commitlint/load@19.8.1(@types/node@22.19.15)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 19.8.1
+      '@commitlint/execute-rule': 19.8.1
+      '@commitlint/resolve-extends': 19.8.1
+      '@commitlint/types': 19.8.1
+      chalk: 5.6.2
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@22.19.15)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      lodash.uniq: 4.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@19.8.1': {}
+
+  '@commitlint/parse@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      conventional-changelog-angular: 7.0.0
+      conventional-commits-parser: 5.0.0
+
+  '@commitlint/read@19.8.1':
+    dependencies:
+      '@commitlint/top-level': 19.8.1
+      '@commitlint/types': 19.8.1
+      git-raw-commits: 4.0.0
+      minimist: 1.2.8
+      tinyexec: 1.0.4
+
+  '@commitlint/resolve-extends@19.8.1':
+    dependencies:
+      '@commitlint/config-validator': 19.8.1
+      '@commitlint/types': 19.8.1
+      global-directory: 4.0.1
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@19.8.1':
+    dependencies:
+      '@commitlint/ensure': 19.8.1
+      '@commitlint/message': 19.8.1
+      '@commitlint/to-lines': 19.8.1
+      '@commitlint/types': 19.8.1
+
+  '@commitlint/to-lines@19.8.1': {}
+
+  '@commitlint/top-level@19.8.1':
+    dependencies:
+      find-up: 7.0.0
+
+  '@commitlint/types@19.8.1':
+    dependencies:
+      '@types/conventional-commits-parser': 5.0.2
+      chalk: 5.6.2
+
+  '@drizzle-team/brocli@0.11.0': {}
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@fastify/accept-negotiator@2.0.1': {}
+
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/cors@11.2.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.5':
+    dependencies:
+      '@fastify/static': 9.0.0
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@js-joda/core@5.7.0': {}
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
+
+  '@jsdevtools/ono@7.1.3': {}
+
+  '@libsql/client@0.15.15':
+    dependencies:
+      '@libsql/core': 0.15.15
+      '@libsql/hrana-client': 0.7.0
+      js-base64: 3.7.8
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.15.15':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.7.0':
+    dependencies:
+      '@libsql/isomorphic-fetch': 0.3.1
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-fetch@0.3.1': {}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
+  '@lukeed/ms@2.0.2': {}
+
+  '@neon-rs/load@0.0.4': {}
+
+  '@next/env@15.5.14': {}
+
+  '@next/swc-darwin-arm64@15.5.14':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.14':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.14':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.14':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.14':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.14':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.14':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.14':
+    optional: true
+
+  '@pinojs/redact@0.4.0': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tediousjs/connection-string@0.5.0': {}
+
+  '@types/bun@1.3.11':
+    dependencies:
+      bun-types: 1.3.11
+
+  '@types/conventional-commits-parser@5.0.2':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/lodash@4.17.24': {}
+
+  '@types/mssql@9.1.11(@azure/core-client@1.10.1)':
+    dependencies:
+      '@types/node': 22.19.15
+      tarn: 3.0.2
+      tedious: 19.2.1(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/readable-stream@4.0.23':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@typespec/ts-http-runtime@0.3.4':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  abstract-logging@2.0.1: {}
+
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-ify@1.0.0: {}
+
+  asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
+
+  axios@1.14.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  bl@6.1.6:
+    dependencies:
+      '@types/readable-stream': 4.0.23
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 4.7.0
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bun-types@1.3.11:
+    dependencies:
+      '@types/node': 22.19.15
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001784: {}
+
+  chalk@5.6.2: {}
+
+  client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@11.1.0: {}
+
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
+  consola@3.4.2: {}
+
+  content-disposition@1.0.1: {}
+
+  conventional-changelog-angular@7.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@5.0.0:
+    dependencies:
+      JSONStream: 1.3.5
+      is-text-path: 2.0.0
+      meow: 12.1.1
+      split2: 4.2.0
+
+  cookie@1.1.1: {}
+
+  cosmiconfig-typescript-loader@6.2.0(@types/node@22.19.15)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 22.19.15
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  csstype@3.2.3: {}
+
+  dargs@8.1.0: {}
+
+  data-uri-to-buffer@4.0.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  dedent@1.7.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.0.2: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  dotenv@16.6.1: {}
+
+  drizzle-kit@1.0.0-beta.9-e89174b:
+    dependencies:
+      '@drizzle-team/brocli': 0.11.0
+      '@js-temporal/polyfill': 0.5.1
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@1.0.0-beta.9-e89174b(@libsql/client@0.15.15)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.20.0)(bun-types@1.3.11)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0):
+    dependencies:
+      '@types/mssql': 9.1.11(@azure/core-client@1.10.1)
+      mssql: 11.0.1(@azure/core-client@1.10.1)
+    optionalDependencies:
+      '@libsql/client': 0.15.15
+      '@types/pg': 8.20.0
+      bun-types: 1.3.11
+      pg: 8.20.0
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  emoji-regex@8.0.0: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
+  fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-uri@3.1.0: {}
+
+  fastify-plugin@5.1.0: {}
+
+  fastify-type-provider-zod@4.0.2(fastify@5.8.4)(zod@3.25.76):
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastify: 5.8.4
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  fastify@5.8.4:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
+
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
+
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  git-raw-commits@4.0.0:
+    dependencies:
+      dargs: 8.1.0
+      meow: 12.1.1
+      split2: 4.2.0
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@4.1.1: {}
+
+  ipaddr.js@2.3.0: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-obj@2.0.0: {}
+
+  is-text-path@2.0.0:
+    dependencies:
+      text-extensions: 2.4.0
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  jiti@2.6.1: {}
+
+  js-base64@3.7.8: {}
+
+  js-md4@0.3.2: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsbi@4.3.2: {}
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  json-schema-to-typescript@15.0.4:
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 11.9.3
+      '@types/json-schema': 7.0.15
+      '@types/lodash': 4.17.24
+      is-glob: 4.0.3
+      js-yaml: 4.1.1
+      lodash: 4.17.23
+      minimist: 1.2.8
+      prettier: 3.8.1
+      tinyglobby: 0.2.15
+
+  json-schema-traverse@1.0.0: {}
+
+  jsonparse@1.3.1: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
+
+  lines-and-columns@1.2.4: {}
+
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.kebabcase@4.1.1: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
+
+  lodash.once@4.1.1: {}
+
+  lodash.snakecase@4.1.1: {}
+
+  lodash.startcase@4.4.0: {}
+
+  lodash.uniq@4.5.0: {}
+
+  lodash.upperfirst@4.3.1: {}
+
+  lodash@4.17.23: {}
+
+  loglevel@1.9.2: {}
+
+  lru-cache@11.2.7: {}
+
+  math-intrinsics@1.1.0: {}
+
+  meow@12.1.1: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@3.0.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  mssql@11.0.1(@azure/core-client@1.10.1):
+    dependencies:
+      '@tediousjs/connection-string': 0.5.0
+      commander: 11.1.0
+      debug: 4.4.3
+      rfdc: 1.4.1
+      tarn: 3.0.2
+      tedious: 18.6.2(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  nanoid@3.3.11: {}
+
+  native-duplexpair@1.0.0: {}
+
+  next@15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 15.5.14
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001784
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.14
+      '@next/swc-darwin-x64': 15.5.14
+      '@next/swc-linux-arm64-gnu': 15.5.14
+      '@next/swc-linux-arm64-musl': 15.5.14
+      '@next/swc-linux-x64-gnu': 15.5.14
+      '@next/swc-linux-x64-musl': 15.5.14
+      '@next/swc-win32-arm64-msvc': 15.5.14
+      '@next/swc-win32-x64-msvc': 15.5.14
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  on-exit-leak-free@2.1.2: {}
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  openapi-types@12.1.3: {}
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.3
+
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-exists@5.0.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.7
+      minipass: 7.1.3
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  prettier@3.8.1: {}
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
+  promise-limit@2.7.0: {}
+
+  proxy-from-env@2.1.0: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react@19.2.4: {}
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  real-require@0.2.0: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
+
+  run-applescript@7.1.0: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
+
+  semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  smol-toml@1.6.1: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
+
+  sprintf-js@1.1.3: {}
+
+  statuses@2.0.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+
+  tarn@3.0.2: {}
+
+  tedious@18.6.2(@azure/core-client@1.10.1):
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.1
+      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
+      '@js-joda/core': 5.7.0
+      '@types/node': 22.19.15
+      bl: 6.1.6
+      iconv-lite: 0.6.3
+      js-md4: 0.3.2
+      native-duplexpair: 1.0.0
+      sprintf-js: 1.1.3
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  tedious@19.2.1(@azure/core-client@1.10.1):
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.1
+      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
+      '@js-joda/core': 5.7.0
+      '@types/node': 22.19.15
+      bl: 6.1.6
+      iconv-lite: 0.7.2
+      js-md4: 0.3.2
+      native-duplexpair: 1.0.0
+      sprintf-js: 1.1.3
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  text-extensions@2.4.0: {}
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
+  through@2.3.8: {}
+
+  tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  toad-cache@3.7.0: {}
+
+  toidentifier@1.0.1: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  typesense@2.1.0(@babel/runtime@7.29.2):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      axios: 1.14.0
+      loglevel: 1.9.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - debug
+
+  undici-types@6.21.0: {}
+
+  unicorn-magic@0.1.0: {}
+
+  uuid@8.3.2: {}
+
+  web-streams-polyfill@3.3.3: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
+  xtend@4.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@1.2.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'
+

--- a/scripts/load-product-data.sh
+++ b/scripts/load-product-data.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGPORT="${PRODUCT_PG_PORT:-54329}"
+DATABASE_URL="${DATABASE_URL:-postgresql://postgres@127.0.0.1:${PGPORT}/giaankhand}"
+ARCHIVE_DATABASE_PATH="${ARCHIVE_DATABASE_PATH:-${ROOT_DIR}/dist/archive/archive.sqlite}"
+TYPESENSE_HOST="${TYPESENSE_HOST:-127.0.0.1}"
+TYPESENSE_PORT="${TYPESENSE_PORT:-8108}"
+TYPESENSE_PROTOCOL="${TYPESENSE_PROTOCOL:-http}"
+TYPESENSE_API_KEY="${TYPESENSE_API_KEY:-xyz}"
+
+createdb -h 127.0.0.1 -p "${PGPORT}" -U postgres giaankhand >/dev/null 2>&1 || true
+
+cd "${ROOT_DIR}"
+
+DATABASE_URL="${DATABASE_URL}" pnpm product:init
+DATABASE_URL="${DATABASE_URL}" \
+ARCHIVE_DATABASE_PATH="${ARCHIVE_DATABASE_PATH}" \
+pnpm product:import
+DATABASE_URL="${DATABASE_URL}" \
+TYPESENSE_HOST="${TYPESENSE_HOST}" \
+TYPESENSE_PORT="${TYPESENSE_PORT}" \
+TYPESENSE_PROTOCOL="${TYPESENSE_PROTOCOL}" \
+TYPESENSE_API_KEY="${TYPESENSE_API_KEY}" \
+pnpm search:index

--- a/scripts/start-local-postgres.sh
+++ b/scripts/start-local-postgres.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGDATA_DIR="${ROOT_DIR}/.tmp/pgdata"
+PGLOG_FILE="${ROOT_DIR}/.tmp/postgres.log"
+PGPORT="${PRODUCT_PG_PORT:-54329}"
+
+mkdir -p "${ROOT_DIR}/.tmp"
+
+if [ ! -d "${PGDATA_DIR}/base" ]; then
+  initdb -D "${PGDATA_DIR}" -A trust -U postgres >/dev/null
+fi
+
+if pg_isready -p "${PGPORT}" >/dev/null 2>&1; then
+  echo "PostgreSQL already running on port ${PGPORT}."
+  exit 0
+fi
+
+pg_ctl -D "${PGDATA_DIR}" -l "${PGLOG_FILE}" -o "-p ${PGPORT}" start
+echo "PostgreSQL started on port ${PGPORT}."

--- a/scripts/start-local-typesense.sh
+++ b/scripts/start-local-typesense.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_DIR="${ROOT_DIR}/.tmp/typesense"
+DATA_DIR="${ROOT_DIR}/.tmp/typesense-data"
+ARCHIVE_NAME="typesense-server-29.0-darwin-arm64.tar.gz"
+ARCHIVE_URL="https://dl.typesense.org/releases/29.0/${ARCHIVE_NAME}"
+PORT="${TYPESENSE_PORT:-8108}"
+API_KEY="${TYPESENSE_API_KEY:-xyz}"
+
+mkdir -p "${TOOLS_DIR}" "${DATA_DIR}"
+
+if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+  echo "Typesense already running on port ${PORT}."
+  exit 0
+fi
+
+if [ ! -x "${TOOLS_DIR}/typesense-server" ]; then
+  curl -L "${ARCHIVE_URL}" -o "${TOOLS_DIR}/${ARCHIVE_NAME}"
+  tar -xzf "${TOOLS_DIR}/${ARCHIVE_NAME}" -C "${TOOLS_DIR}"
+fi
+
+nohup "${TOOLS_DIR}/typesense-server" \
+  --data-dir="${DATA_DIR}" \
+  --api-key="${API_KEY}" \
+  --listen-port="${PORT}" \
+  --enable-cors \
+  > "${ROOT_DIR}/.tmp/typesense.log" 2>&1 &
+
+for _ in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "Typesense started on port ${PORT}."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Typesense failed to start." >&2
+exit 1

--- a/scripts/start-product-apps.sh
+++ b/scripts/start-product-apps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGPORT="${PRODUCT_PG_PORT:-54329}"
+API_PORT="${API_PORT:-4100}"
+WEB_PORT="${WEB_PORT:-3001}"
+
+DATABASE_URL="${DATABASE_URL:-postgresql://postgres@127.0.0.1:${PGPORT}/giaankhand}"
+TYPESENSE_HOST="${TYPESENSE_HOST:-127.0.0.1}"
+TYPESENSE_PORT="${TYPESENSE_PORT:-8108}"
+TYPESENSE_PROTOCOL="${TYPESENSE_PROTOCOL:-http}"
+TYPESENSE_API_KEY="${TYPESENSE_API_KEY:-xyz}"
+NEXT_PUBLIC_API_BASE_URL="${NEXT_PUBLIC_API_BASE_URL:-http://127.0.0.1:${API_PORT}}"
+
+cd "${ROOT_DIR}"
+
+nohup env \
+  DATABASE_URL="${DATABASE_URL}" \
+  TYPESENSE_HOST="${TYPESENSE_HOST}" \
+  TYPESENSE_PORT="${TYPESENSE_PORT}" \
+  TYPESENSE_PROTOCOL="${TYPESENSE_PROTOCOL}" \
+  TYPESENSE_API_KEY="${TYPESENSE_API_KEY}" \
+  API_PORT="${API_PORT}" \
+  pnpm --filter @giaan-khand/api exec tsx src/server.ts \
+  > "${ROOT_DIR}/.tmp/api.log" 2>&1 &
+
+nohup env \
+  NEXT_PUBLIC_API_BASE_URL="${NEXT_PUBLIC_API_BASE_URL}" \
+  pnpm --filter @giaan-khand/web exec next dev -p "${WEB_PORT}" \
+  > "${ROOT_DIR}/.tmp/web.log" 2>&1 &
+
+echo "API starting on http://127.0.0.1:${API_PORT}"
+echo "Web starting on http://127.0.0.1:${WEB_PORT}"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "#archive/*": ["archive/src/*"],
+      "#collections-types/*": ["collections/$schemas/.types/*"],
+      "#~/*": ["src/*"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "verbatimModuleSyntax": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a `pnpm` workspace with a Next.js web app, Fastify API, shared contracts, typed SDK, and pangti search-core package
- port the static search UI into SSR-friendly React routes for `/`, `/search`, and `/works/[slug]`
- add the Postgres read model importer, Typesense indexer, local stack scripts, and coverage for API, search-core, contracts, SDK, and web state helpers

## Plan
- original approved plan: `docs/plans/giaan-khand-search-port-plan.md`

## Verification
- `pnpm test:api`
- `pnpm test:search-core`
- `pnpm exec tsx --test packages/contracts/src/contracts.spec.ts packages/sdk/src/client.spec.ts`
- `pnpm --filter @giaan-khand/web test`
- `pnpm --filter @giaan-khand/web typecheck`
- `pnpm --filter @giaan-khand/web build`
- imported the archive into local Postgres and indexed pangtis into local Typesense
- validated live API and SSR web responses locally

## Notes
- local stack runbook: `docs/local-product-stack.md`
- API OpenAPI output: `apps/api/openapi.json`
